### PR TITLE
feat(etl_framework): add ETL reporter with warnings/errors/run-time views

### DIFF
--- a/etl_framework/README.md
+++ b/etl_framework/README.md
@@ -1,7 +1,7 @@
 # ETL Framework for Odoo
 
-**Version:** 2.2  
-**Last Updated:** January 8, 2026
+**Version:** 2.3  
+**Last Updated:** February 6, 2026
 
 ---
 
@@ -57,41 +57,30 @@ from odoo.addons.etl_framework import ETL, ETLContext, PipelineOrchestrator
 - No silent failures or recovery attempts
 - Clear error messages for debugging
 
+### 6. **Observable Execution**
+- Built-in import reporting persisted to Odoo models
+- Auto-capture of `WARNING` and `ERROR` log messages during pipeline execution
+- Pipeline code can explicitly log successes, warnings, and failures via `ctx.report`
+- Reports are browsable through the Odoo UI under **ETL > Import Reports**
+
 ---
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    ETL Pipeline Registry                     │
-│  (Stores all decorated pipelines and their configurations)  │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                   Pipeline Orchestrator                      │
-│  • Resolves model dependencies (topological sort)            │
-│  • Executes pipelines in correct order                       │
-│  • Manages database connections and commits                  │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                      ETL Executor                            │
-│  1. Execute Extract methods                                  │
-│  2. Count extracted records                                  │
-│  3. Decide: Single-process or Multiprocessing?              │
-│  4. Execute Transform + Load accordingly                     │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                    ┌─────────┴─────────┐
-                    ▼                   ▼
-         ┌──────────────────┐  ┌──────────────────┐
-         │ Single Process   │  │ Multiprocessing  │
-         │ • Sequential     │  │ • Chunk data     │
-         │ • Simple         │  │ • Fork workers   │
-         │ • Fast for small │  │ • Fast for large │
-         └──────────────────┘  └──────────────────┘
+```mermaid
+graph TD
+    A["**ETL Pipeline Registry**<br/>Stores all decorated pipelines<br/>and their configurations"]
+    B["**Pipeline Orchestrator**<br/>• Resolves model dependencies (topological sort)<br/>• Executes pipelines in correct order<br/>• Manages database connections and commits<br/>• Creates ETLReporter for the run"]
+    C["**ETL Executor**<br/>1. Execute Extract methods<br/>2. Count extracted records<br/>3. Install log handler (auto-capture WARNING+)<br/>4. Decide: Single-process or Multiprocessing?<br/>5. Execute Transform + Load accordingly<br/>6. Persist pipeline report"]
+    D["**Single Process**<br/>• Sequential<br/>• Simple<br/>• Fast for small"]
+    E["**Multiprocessing**<br/>• Chunk data<br/>• Fork workers<br/>• Fast for large"]
+    F["**ETL Reporter**<br/>• Tracks per-pipeline results<br/>• Auto-captures log messages<br/>• Persists to etl.import.report"]
+
+    A --> B --> C
+    C --> D
+    C --> E
+    B --> F
+    C --> F
 ```
 
 ---
@@ -110,6 +99,10 @@ class ETLContext:
 
     def get_config(self, key: str, default: Any = None) -> Any:
         """Retrieve a configuration value."""
+
+    @property
+    def report(self) -> PipelineReport:
+        """Access the active pipeline report (no-op if no reporter)."""
 ```
 
 Example source configuration:
@@ -377,13 +370,72 @@ This allows:
 
 ---
 
+## Import Reporting
+
+The framework automatically tracks every ETL run and persists results to Odoo models, viewable under **ETL > Import Reports**.
+
+### Automatic Reporting
+
+The following are tracked automatically with zero pipeline code changes:
+
+- **Extracted record count** per pipeline (note: this reflects the total records returned by the extract phase, including records that may already exist in Odoo if the extract does not filter them)
+- **Pipeline duration** and state (Done / Failed)
+- **Uncaught exceptions** recorded as failure details
+- **Logged warnings** (`_logger.warning(...)`) captured as report warnings
+- **Logged errors** (`_logger.error(...)`) captured as report failures
+
+Log messages from the `etl_framework` module itself (retry warnings, progress info, etc.) are excluded from capture.
+
+### Explicit Reporting API
+
+Pipelines can also log results explicitly via `ctx.report`:
+
+```python
+@ETL.load()
+def load_records(self, ctx: ETLContext, transformed: dict):
+    for vals in transformed.get("transform_records", []):
+        try:
+            ctx.env["res.partner"].create(vals)
+            ctx.report.success()
+        except Exception as e:
+            # Log failure without raising — processing continues
+            ctx.report.failure(message=str(e), source_ref=vals.get("name"))
+```
+
+Available methods on `ctx.report`:
+
+| Method | Description |
+|--------|-------------|
+| `success(count=1)` | Increment success counter |
+| `warning(message, source_ref=None)` | Log a warning detail |
+| `failure(message, source_ref=None)` | Log a failure detail (non-throwing) |
+
+If no reporter is active, `ctx.report` returns a no-op object — safe to call unconditionally.
+
+### Report Models
+
+| Model | Description |
+|-------|-------------|
+| `etl.import.report` | One record per ETL run (start/end time, totals, state) |
+| `etl.import.report.line` | One record per pipeline (extracted count, success/warning/failure counts) |
+| `etl.import.report.detail` | Individual warning/failure messages with source references |
+
+---
+
 ## API Reference
 
-See inline documentation in `framework.py` for complete API details.
+See inline documentation in `framework.py` and `reporter.py` for complete API details.
 
 ---
 
 ## Changelog
+
+### v2.3 (February 2026)
+- **Import reporting**: Persistent ETL run reports with per-pipeline success/warning/failure tracking
+- **Auto-capture of log messages**: `WARNING` and `ERROR` log messages during pipeline execution are automatically recorded as report details
+- **Explicit reporting API**: Pipelines can log successes, warnings, and failures via `ctx.report` without raising exceptions
+- **Browsable report views**: Tree and form views under **ETL > Import Reports** with state indicators and drill-down to details
+- **Worker error handling**: Worker processes now rollback cleanly on error, preventing `InFailedSqlTransaction` from masking the original exception
 
 ### v2.2 (January 2026)
 - **Generic source configuration**: Replaced SAP-specific `sap_db_id` with generic `source_config` dictionary

--- a/etl_framework/__init__.py
+++ b/etl_framework/__init__.py
@@ -1,6 +1,7 @@
 # ETL Framework for Odoo
 # Declarative, self-optimizing ETL pipelines
 
+from . import models
 from .framework import (
     ETL,
     ETLContext,
@@ -10,9 +11,10 @@ from .framework import (
     ETLPipeline,
     MultiprocessingConfig,
     PipelineOrchestrator,
-    RETRYABLE_ERRORS,
+    RETRYABLE_DB_ERRORS,
     ChunkableData,
 )
+from .reporter import ETLReporter, PipelineReport
 
 __all__ = [
     "ETL",
@@ -21,8 +23,10 @@ __all__ = [
     "ETLMethod",
     "ETLPhase",
     "ETLPipeline",
+    "ETLReporter",
     "MultiprocessingConfig",
     "PipelineOrchestrator",
-    "RETRYABLE_ERRORS",
+    "RETRYABLE_DB_ERRORS",
     "ChunkableData",
+    "PipelineReport",
 ]

--- a/etl_framework/__manifest__.py
+++ b/etl_framework/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "ETL Framework",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "category": "Technical",
     "summary": "Declarative, self-optimizing ETL framework for Odoo",
     "description": """
@@ -25,7 +25,10 @@ See the module README for usage examples.
     "website": "https://www.bemade.org",
     "license": "LGPL-3",
     "depends": ["base"],
-    "data": [],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/etl_import_report_views.xml",
+    ],
     "installable": True,
     "auto_install": False,
 }

--- a/etl_framework/framework.py
+++ b/etl_framework/framework.py
@@ -27,13 +27,14 @@ from dataclasses import dataclass, field
 import psycopg2
 import psycopg2.errors
 import psycopg2.extensions
+from contextlib import contextmanager
 from enum import Enum
 
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-# Errors that should bubble up for retry by the orchestrator
-# These are transient database errors that can be resolved by retrying
-RETRYABLE_ERRORS = (
+# DB errors that must propagate for chunk-level retry.
+# Everything else inside a savepoint is safe to skip.
+RETRYABLE_DB_ERRORS = (
     psycopg2.errors.SerializationFailure,
     psycopg2.errors.DeadlockDetected,
     psycopg2.extensions.TransactionRollbackError,
@@ -74,11 +75,8 @@ class ChunkableData:
         return self.context.get(key, default)
 
 
-from contextlib import contextmanager
-
 from odoo import api
-from odoo.modules.registry import Registry
-from odoo.tools import mute_logger
+from .reporter import ETLReporter, PipelineReport, ReportLogHandler
 
 
 @contextmanager
@@ -147,6 +145,20 @@ class ETLContext:
     cr: Any  # Source database cursor
     env: Any  # Odoo environment
     source_config: Optional[Dict[str, Any]] = None  # Source-specific config
+    _reporter: Optional[Any] = field(default=None, repr=False)  # ETLReporter
+
+    @property
+    def report(self) -> PipelineReport:
+        """Get the current pipeline report for logging successes/warnings/failures.
+
+        Returns a no-op PipelineReport if no reporter is active, so callers
+        can always safely call ctx.report.success() etc.
+        """
+        if self._reporter and self._reporter.current:
+            return self._reporter.current
+        # Return a detached no-op report so pipeline code never has to
+        # check for None.
+        return PipelineReport(pipeline_name="_detached")
 
     def get_config(self, key: str, default: Any = None) -> Any:
         """Get a configuration value from source_config.
@@ -161,6 +173,35 @@ class ETLContext:
         if self.source_config:
             return self.source_config.get(key, default)
         return default
+
+    @contextmanager
+    def skippable(self, source_ref: str = ""):
+        """Context manager for per-record operations that may fail.
+
+        Wraps the block in a DB savepoint. If a retryable DB error occurs
+        (serialization, deadlock), it propagates so the framework can retry
+        the whole chunk. Any other exception is caught, logged as a warning
+        on the ETL report, and execution continues to the next record.
+
+        Usage::
+
+            for record in records:
+                with ctx.skippable(f"record {record.id}"):
+                    record.action_post()
+                    (line_a + line_b).reconcile()
+
+        Args:
+            source_ref: Human-readable reference for the report detail
+                (e.g. SAP document number).
+        """
+        try:
+            with self.env.cr.savepoint():
+                yield
+        except RETRYABLE_DB_ERRORS:
+            raise
+        except Exception as e:
+            _logger.warning("Skipping %s: %s", source_ref, e)
+            self.report.failure(message=str(e), source_ref=source_ref)
 
 
 @dataclass
@@ -531,32 +572,66 @@ class ETLExecutor:
 
     def execute(self) -> None:
         """Execute the complete ETL pipeline."""
+        pipeline_name = self.pipeline.importer_model_name
+        reporter = self.ctx._reporter
+
         _logger.info(
             f"Starting ETL pipeline for {self.pipeline.target_model} "
-            f"(importer: {self.pipeline.importer_model_name})"
+            f"(importer: {pipeline_name})"
         )
 
-        # Phase 1: Extract
-        extracted_data = self._execute_extract()
+        # Start reporter tracking for this pipeline
+        if reporter:
+            reporter.start_pipeline(
+                pipeline_name=pipeline_name,
+                target_model=self.pipeline.target_model,
+            )
 
-        # Phase 2: Decide execution strategy
-        record_count = self._get_record_count(extracted_data)
-        use_multiprocessing = self.pipeline.multiprocessing.should_use_multiprocessing(
-            record_count
-        )
+        # Install log handler to auto-capture WARNING+ messages
+        log_handler = None
+        if reporter and reporter.current:
+            log_handler = ReportLogHandler(reporter.current)
+            logging.getLogger().addHandler(log_handler)
 
-        _logger.info(
-            f"Extracted {record_count} records. "
-            f"Using {'multiprocessing' if use_multiprocessing else 'single-process'} mode."
-        )
+        state = "done"
+        try:
+            # Phase 1: Extract
+            extracted_data = self._execute_extract()
 
-        # Phase 3 & 4: Transform and Load
-        if use_multiprocessing:
-            self._execute_parallel(extracted_data)
-        else:
-            self._execute_sequential(extracted_data)
+            # Phase 2: Decide execution strategy
+            record_count = self._get_record_count(extracted_data)
 
-        _logger.info(f"[{self.pipeline.importer_model_name}] Completed ETL pipeline")
+            # Auto-track extracted count
+            if reporter and reporter.current:
+                reporter.current.extracted_count = record_count
+
+            use_multiprocessing = (
+                self.pipeline.multiprocessing.should_use_multiprocessing(record_count)
+            )
+
+            _logger.info(
+                f"Extracted {record_count} records. "
+                f"Using {'multiprocessing' if use_multiprocessing else 'single-process'} mode."
+            )
+
+            # Phase 3 & 4: Transform and Load
+            if use_multiprocessing:
+                self._execute_parallel(extracted_data)
+            else:
+                self._execute_sequential(extracted_data)
+
+            _logger.info(f"[{pipeline_name}] Completed ETL pipeline")
+        except Exception as e:
+            state = "failed"
+            # Record the uncaught exception as a failure detail
+            if reporter and reporter.current:
+                reporter.current.failure(message=str(e), source_ref="(uncaught)")
+            raise
+        finally:
+            if log_handler:
+                logging.getLogger().removeHandler(log_handler)
+            if reporter:
+                reporter.end_pipeline(state=state)
 
     def _execute_extract(self) -> Dict[str, Any]:
         """Execute all extraction methods.
@@ -569,7 +644,8 @@ class ETLExecutor:
             _logger.info(
                 f"[{self.pipeline.importer_model_name}] Extracting from {method.source_table}"
             )
-            result = method.func(self.importer, self.ctx)
+            bound = getattr(self.importer, method.func.__name__)
+            result = bound(self.ctx)
             results[method.func.__name__] = result
         return results
 
@@ -610,7 +686,8 @@ class ETLExecutor:
             _logger.info(
                 f"[{self.pipeline.importer_model_name}] Transforming with {method.func.__name__}"
             )
-            result = method.func(self.importer, self.ctx, extracted_data)
+            bound = getattr(self.importer, method.func.__name__)
+            result = bound(self.ctx, extracted_data)
             transformed_data[method.func.__name__] = result
 
         # Load
@@ -618,7 +695,8 @@ class ETLExecutor:
             _logger.info(
                 f"[{self.pipeline.importer_model_name}] Loading with {method.func.__name__}"
             )
-            method.func(self.importer, self.ctx, transformed_data)
+            bound = getattr(self.importer, method.func.__name__)
+            bound(self.ctx, transformed_data)
 
     def _execute_parallel(self, extracted_data: Dict[str, Any]) -> None:
         """Execute transform and load using multiprocessing.
@@ -630,7 +708,7 @@ class ETLExecutor:
         chunks = self._create_chunks(extracted_data)
 
         mp_config = self.pipeline.multiprocessing
-        workers = mp_config.get_workers()
+        workers = min(mp_config.get_workers(), len(chunks))
 
         _logger.info(
             f"[{self.pipeline.importer_model_name}] Processing {len(chunks)} chunks with {workers} workers."
@@ -672,7 +750,25 @@ class ETLExecutor:
                                     f"[{self.pipeline.importer_model_name}] Completed chunk {i}/{len(chunks)}"
                                 )
                                 break
-                            except RETRYABLE_ERRORS as e:
+                            except Exception as e:
+                                # Locate a retryable database error anywhere in the exception chain
+                                retryable_exc = self._find_retryable_db_error(e)
+
+                                _logger.warning(
+                                    "Chunk %s caught exception=%s, retryable=%s, chain=%s",
+                                    i,
+                                    type(e).__name__,
+                                    (
+                                        type(retryable_exc).__name__
+                                        if retryable_exc
+                                        else "None"
+                                    ),
+                                    self._summarize_exception_chain(e),
+                                )
+
+                                if not retryable_exc:
+                                    # Not a retryable error, crash immediately
+                                    raise
                                 if attempt < max_retries - 1:
                                     wait_time = 2**attempt  # Exponential backoff
                                     _logger.warning(
@@ -693,11 +789,6 @@ class ETLExecutor:
                                 else:
                                     # Max retries exceeded
                                     raise
-                            except Exception as e:
-                                _logger.error(
-                                    "Multiprocessing execution failed", exc_info=True
-                                )
-                                raise
             except Exception:
                 _logger.error("Multiprocessing execution failed", exc_info=True)
                 raise
@@ -721,6 +812,8 @@ class ETLExecutor:
         retryable = (
             psycopg2.errors.SerializationFailure,
             psycopg2.errors.DeadlockDetected,
+            psycopg2.errors.InFailedSqlTransaction,
+            psycopg2.errors.ActiveSqlTransaction,
             psycopg2.extensions.TransactionRollbackError,
         )
         for chained_exc in self._iter_exception_chain(exc):
@@ -833,34 +926,40 @@ class ETLExecutor:
             chunk: Data chunk to process.
             target_model: Target Odoo model name.
         """
-        from odoo.sql_db import db_connect
+        from odoo.modules.registry import Registry
 
-        # Use db_connect directly to get a fresh connection, avoiding
-        # inherited connection pool state issues after fork
-        db = db_connect(dbname)
-        cr = db.cursor()
-        try:
-            env = api.Environment(cr, uid, context)
-            importer = env[importer_name]
-            pipeline = importer._etl_pipeline  # type: ignore[attr-defined]
+        with Registry(dbname).cursor() as cr:
+            try:
+                env = api.Environment(cr, uid, context)
+                importer = env[importer_name]
+                pipeline = importer._etl_pipeline  # type: ignore[attr-defined]
 
-            # Create ETL context with Odoo cursor (no SAP cursor in multiprocessing)
-            ctx = ETLContext(cr=None, env=env)
+                ctx = ETLContext(cr=None, env=env)
 
-            # Transform
-            extracted_dict = chunk
-            transformed_data = {}
-            for method in pipeline.transform_methods:
-                result = method.func(importer, ctx, extracted_dict)
-                transformed_data[method.func.__name__] = result
+                # Transform
+                extracted_dict = chunk
+                transformed_data = {}
+                for method in pipeline.transform_methods:
+                    bound = getattr(importer, method.func.__name__)
+                    result = bound(ctx, extracted_dict)
+                    transformed_data[method.func.__name__] = result
 
-            # Load
-            for method in pipeline.load_methods:
-                method.func(importer, ctx, transformed_data)
+                # Load
+                for method in pipeline.load_methods:
+                    bound = getattr(importer, method.func.__name__)
+                    bound(ctx, transformed_data)
 
-            cr.commit()
-        finally:
-            cr.close()
+                cr.commit()
+            except Exception:
+                # Rollback the underlying PG connection directly so it is
+                # returned to the pool in a clean state.  Odoo's
+                # Cursor._close() deletes the psycopg2 cursor before
+                # calling rollback(), which can silently fail and leave
+                # the connection with an active transaction — causing
+                # "DISCARD ALL cannot run inside a transaction block" on
+                # the next borrow().
+                cr._cnx.rollback()
+                raise
 
 
 # =============================================================================
@@ -917,28 +1016,24 @@ class PipelineOrchestrator:
         execution_order = self._resolve_dependencies()
         _logger.info(f"Execution order: {execution_order}")
 
-        # Execute each pipeline
-        ctx = ETLContext(cr=cr, env=self.env, source_config=self.source_config)
+        # Create reporter and context
+        reporter = ETLReporter(self.env)
+        reporter.start_run()
+        ctx = ETLContext(
+            cr=cr,
+            env=self.env,
+            source_config=self.source_config,
+            _reporter=reporter,
+        )
 
-        for importer_name in execution_order:
-            pipeline = self.pipelines.get(importer_name)
-            if not pipeline:
-                _logger.warning(f"Pipeline for {importer_name} not found, skipping")
-                continue
-
-            # Get importer instance using the importer name
-            importer = self.env[importer_name]
-
-            _logger.info(
-                f"Starting ETL pipeline for {pipeline.target_model} (importer: {importer_name})"
-            )
-
-            # Execute pipeline
-            executor = ETLExecutor(pipeline, ctx, importer)
-            executor.execute()
-
-            # Commit after each pipeline
-            self.env.cr.commit()
+        run_state = "done"
+        try:
+            self._run_pipelines(execution_order, ctx)
+        except Exception:
+            run_state = "failed"
+            raise
+        finally:
+            reporter.end_run(state=run_state)
 
         _logger.info("Completed ETL orchestration for all pipelines")
 
@@ -955,9 +1050,36 @@ class PipelineOrchestrator:
         execution_order = self._resolve_dependencies_for(pipeline_names)
         _logger.info(f"Execution order: {execution_order}")
 
-        # Execute each pipeline
-        ctx = ETLContext(cr=cr, env=self.env, source_config=self.source_config)
+        # Create reporter and context
+        reporter = ETLReporter(self.env)
+        reporter.start_run()
+        ctx = ETLContext(
+            cr=cr,
+            env=self.env,
+            source_config=self.source_config,
+            _reporter=reporter,
+        )
 
+        run_state = "done"
+        try:
+            self._run_pipelines(execution_order, ctx)
+        except Exception:
+            run_state = "failed"
+            raise
+        finally:
+            reporter.end_run(state=run_state)
+
+        _logger.info(
+            f"Completed ETL orchestration for {len(execution_order)} pipelines"
+        )
+
+    def _run_pipelines(self, execution_order: List[str], ctx: ETLContext) -> None:
+        """Execute pipelines in the given order.
+
+        Args:
+            execution_order: List of importer names in execution order.
+            ctx: ETL context (with reporter attached).
+        """
         for importer_name in execution_order:
             pipeline = self.pipelines.get(importer_name)
             if not pipeline:
@@ -968,7 +1090,8 @@ class PipelineOrchestrator:
             importer = self.env[importer_name]
 
             _logger.info(
-                f"Starting ETL pipeline for {pipeline.target_model} (importer: {importer_name})"
+                f"Starting ETL pipeline for {pipeline.target_model} "
+                f"(importer: {importer_name})"
             )
 
             # Execute pipeline
@@ -977,10 +1100,6 @@ class PipelineOrchestrator:
 
             # Commit after each pipeline
             self.env.cr.commit()
-
-        _logger.info(
-            f"Completed ETL orchestration for {len(execution_order)} pipelines"
-        )
 
     def _resolve_dependencies(self) -> List[str]:
         """Resolve pipeline dependencies using topological sort.

--- a/etl_framework/models/__init__.py
+++ b/etl_framework/models/__init__.py
@@ -1,0 +1,1 @@
+from . import etl_import_report

--- a/etl_framework/models/etl_import_report.py
+++ b/etl_framework/models/etl_import_report.py
@@ -1,0 +1,148 @@
+import logging
+from datetime import timedelta
+
+from odoo import _, api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ETLImportReport(models.Model):
+    """Top-level report for an ETL import run."""
+
+    _name = "etl.import.report"
+    _description = "ETL Import Report"
+    _order = "create_date desc"
+
+    name = fields.Char(compute="_compute_name", store=True)
+    state = fields.Selection(
+        [
+            ("running", "Running"),
+            ("done", "Done"),
+            ("failed", "Failed"),
+        ],
+        default="running",
+        readonly=True,
+    )
+    start_time = fields.Datetime(default=fields.Datetime.now, readonly=True)
+    end_time = fields.Datetime(readonly=True)
+    duration = fields.Float(
+        compute="_compute_duration", store=True, string="Duration (s)"
+    )
+    line_ids = fields.One2many(
+        "etl.import.report.line", "report_id", string="Pipeline Results"
+    )
+    total_success = fields.Integer(compute="_compute_totals", store=True)
+    total_warning = fields.Integer(compute="_compute_totals", store=True)
+    total_failure = fields.Integer(compute="_compute_totals", store=True)
+
+    @api.depends("start_time")
+    def _compute_name(self):
+        for rec in self:
+            if rec.start_time:
+                rec.name = _("ETL Import — %s") % fields.Datetime.to_string(
+                    rec.start_time
+                )
+            else:
+                rec.name = _("ETL Import (draft)")
+
+    @api.depends("start_time", "end_time")
+    def _compute_duration(self):
+        for rec in self:
+            if rec.start_time and rec.end_time:
+                delta = rec.end_time - rec.start_time
+                rec.duration = delta.total_seconds()
+            else:
+                rec.duration = 0.0
+
+    @api.depends("line_ids.success_count", "line_ids.warning_count", "line_ids.failure_count")
+    def _compute_totals(self):
+        for rec in self:
+            rec.total_success = sum(rec.line_ids.mapped("success_count"))
+            rec.total_warning = sum(rec.line_ids.mapped("warning_count"))
+            rec.total_failure = sum(rec.line_ids.mapped("failure_count"))
+
+    def action_mark_done(self):
+        self.write({"state": "done", "end_time": fields.Datetime.now()})
+
+    def action_mark_failed(self):
+        self.write({"state": "failed", "end_time": fields.Datetime.now()})
+
+
+class ETLImportReportLine(models.Model):
+    """Per-pipeline results within an import report."""
+
+    _name = "etl.import.report.line"
+    _description = "ETL Import Report Line"
+    _order = "sequence, id"
+
+    report_id = fields.Many2one(
+        "etl.import.report", required=True, ondelete="cascade"
+    )
+    sequence = fields.Integer(default=10)
+    pipeline_name = fields.Char(required=True, string="Pipeline")
+    target_model = fields.Char(string="Target Model")
+    state = fields.Selection(
+        [
+            ("running", "Running"),
+            ("done", "Done"),
+            ("failed", "Failed"),
+        ],
+        default="running",
+        readonly=True,
+    )
+    start_time = fields.Datetime(readonly=True)
+    end_time = fields.Datetime(readonly=True)
+    duration = fields.Float(
+        compute="_compute_duration", store=True, string="Duration (s)"
+    )
+    extracted_count = fields.Integer(string="Extracted", readonly=True)
+    success_count = fields.Integer(string="Successes", readonly=True)
+    warning_count = fields.Integer(
+        compute="_compute_detail_counts", store=True, string="Warnings"
+    )
+    failure_count = fields.Integer(
+        compute="_compute_detail_counts", store=True, string="Failures"
+    )
+    detail_ids = fields.One2many(
+        "etl.import.report.detail", "line_id", string="Details"
+    )
+
+    @api.depends("start_time", "end_time")
+    def _compute_duration(self):
+        for rec in self:
+            if rec.start_time and rec.end_time:
+                delta = rec.end_time - rec.start_time
+                rec.duration = delta.total_seconds()
+            else:
+                rec.duration = 0.0
+
+    @api.depends("detail_ids.level")
+    def _compute_detail_counts(self):
+        for rec in self:
+            details = rec.detail_ids
+            rec.warning_count = len(details.filtered(lambda d: d.level == "warning"))
+            rec.failure_count = len(details.filtered(lambda d: d.level == "failure"))
+
+
+class ETLImportReportDetail(models.Model):
+    """Individual warning or failure detail within a pipeline report line."""
+
+    _name = "etl.import.report.detail"
+    _description = "ETL Import Report Detail"
+    _order = "id"
+
+    line_id = fields.Many2one(
+        "etl.import.report.line", required=True, ondelete="cascade"
+    )
+    level = fields.Selection(
+        [
+            ("warning", "Warning"),
+            ("failure", "Failure"),
+        ],
+        required=True,
+    )
+    source_ref = fields.Char(
+        string="Source Record",
+        help="Identifier of the source record (e.g. SAP document number)",
+    )
+    message = fields.Text(required=True)

--- a/etl_framework/reporter.py
+++ b/etl_framework/reporter.py
@@ -1,0 +1,233 @@
+"""ETL Pipeline Reporter API.
+
+Provides a lightweight API for ETL pipelines to report successes, warnings,
+and failures during execution. The reporter accumulates results in memory
+and flushes them to persistent Odoo models (etl.import.report.*) at the
+end of each pipeline or orchestration run.
+
+Usage in pipelines::
+
+    @ETL.load()
+    def load_products(self, ctx, transformed):
+        for vals in transformed['transform_products']:
+            try:
+                ctx.env['product.product'].create(vals)
+                ctx.report.success()
+            except Exception as e:
+                ctx.report.failure(
+                    source_ref=vals.get('sap_item_code'),
+                    message=str(e),
+                )
+
+    # Warnings for non-fatal issues:
+    ctx.report.warning(
+        source_ref='ITEM-001',
+        message='Missing category, using default',
+    )
+"""
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ReportDetail:
+    """A single warning or failure detail."""
+
+    level: str  # 'warning' or 'failure'
+    source_ref: Optional[str] = None
+    message: str = ""
+
+
+@dataclass
+class PipelineReport:
+    """Accumulated results for a single pipeline execution."""
+
+    pipeline_name: str
+    target_model: str = ""
+    extracted_count: int = 0
+    success_count: int = 0
+    details: List[ReportDetail] = field(default_factory=list)
+    _start_time: float = field(default_factory=time.time)
+
+    def success(self, count: int = 1):
+        """Record successful record(s).
+
+        Args:
+            count: Number of records successfully processed.
+        """
+        self.success_count += count
+
+    def warning(self, message: str, source_ref: Optional[str] = None):
+        """Record a warning for a record.
+
+        Args:
+            message: Description of the warning.
+            source_ref: Identifier of the source record (e.g. SAP doc number).
+        """
+        self.details.append(
+            ReportDetail(level="warning", source_ref=source_ref, message=message)
+        )
+
+    def failure(self, message: str, source_ref: Optional[str] = None):
+        """Record a failure for a record.
+
+        Args:
+            message: Description of the failure.
+            source_ref: Identifier of the source record.
+        """
+        self.details.append(
+            ReportDetail(level="failure", source_ref=source_ref, message=message)
+        )
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for d in self.details if d.level == "warning")
+
+    @property
+    def failure_count(self) -> int:
+        return sum(1 for d in self.details if d.level == "failure")
+
+
+class ReportLogHandler(logging.Handler):
+    """Logging handler that captures WARNING+ messages into a PipelineReport.
+
+    Installed temporarily during pipeline execution to auto-capture logged
+    warnings and errors without requiring any changes to existing pipelines.
+
+    WARNING-level log messages become report warnings.
+    ERROR/CRITICAL-level log messages become report failures.
+    """
+
+    def __init__(self, report: PipelineReport):
+        super().__init__(level=logging.WARNING)
+        self._report = report
+
+    _FRAMEWORK_PREFIX = "odoo.addons.etl_framework"
+
+    def emit(self, record: logging.LogRecord):
+        # Skip all etl_framework-internal log messages (reporter, executor, retries…)
+        if record.name.startswith(self._FRAMEWORK_PREFIX):
+            return
+        msg = self.format(record)
+        if record.levelno >= logging.ERROR:
+            self._report.failure(message=msg, source_ref=f"(logged:{record.name})")
+        else:
+            self._report.warning(message=msg, source_ref=f"(logged:{record.name})")
+
+
+class ETLReporter:
+    """Manages reporting for an entire ETL run (one or more pipelines).
+
+    Created by the orchestrator or executor, attached to ETLContext.
+    Persists results to etl.import.report models.
+    """
+
+    def __init__(self, env: Any):
+        """Initialize the reporter.
+
+        Args:
+            env: Odoo environment for creating report records.
+        """
+        self.env = env
+        self._report_record = None
+        self._current_pipeline: Optional[PipelineReport] = None
+        self._pipeline_sequence = 0
+
+    def start_run(self):
+        """Start a new import run. Creates the top-level report record."""
+        self._report_record = self.env["etl.import.report"].create({})
+        self.env.cr.commit()
+        _logger.info("ETL Report created: ID %s", self._report_record.id)
+        return self._report_record
+
+    def start_pipeline(self, pipeline_name: str, target_model: str = ""):
+        """Start tracking a new pipeline within the current run.
+
+        Args:
+            pipeline_name: Importer model name.
+            target_model: Target Odoo model name.
+        """
+        self._pipeline_sequence += 10
+        self._current_pipeline = PipelineReport(
+            pipeline_name=pipeline_name,
+            target_model=target_model,
+        )
+
+    def end_pipeline(self, state: str = "done"):
+        """Finalize the current pipeline and persist its results.
+
+        Args:
+            state: Final state ('done' or 'failed').
+        """
+        if not self._current_pipeline or not self._report_record:
+            return
+
+        pr = self._current_pipeline
+        from odoo import fields as odoo_fields
+
+        line_vals = {
+            "report_id": self._report_record.id,
+            "sequence": self._pipeline_sequence,
+            "pipeline_name": pr.pipeline_name,
+            "target_model": pr.target_model,
+            "state": state,
+            "start_time": odoo_fields.Datetime.to_string(
+                odoo_fields.Datetime.from_string(
+                    time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(pr._start_time))
+                )
+            ),
+            "end_time": odoo_fields.Datetime.now(),
+            "extracted_count": pr.extracted_count,
+            "success_count": pr.success_count,
+        }
+
+        line = self.env["etl.import.report.line"].create(line_vals)
+
+        # Create detail records in batch
+        if pr.details:
+            detail_vals = [
+                {
+                    "line_id": line.id,
+                    "level": d.level,
+                    "source_ref": d.source_ref or False,
+                    "message": d.message,
+                }
+                for d in pr.details
+            ]
+            self.env["etl.import.report.detail"].create(detail_vals)
+
+        self.env.cr.commit()
+        self._current_pipeline = None
+
+        _logger.info(
+            "Pipeline %s: %d success, %d warning, %d failure",
+            pr.pipeline_name,
+            pr.success_count,
+            pr.warning_count,
+            pr.failure_count,
+        )
+
+    def end_run(self, state: str = "done"):
+        """Finalize the import run.
+
+        Args:
+            state: Final state ('done' or 'failed').
+        """
+        if not self._report_record:
+            return
+
+        if state == "done":
+            self._report_record.action_mark_done()
+        else:
+            self._report_record.action_mark_failed()
+        self.env.cr.commit()
+
+    @property
+    def current(self) -> Optional[PipelineReport]:
+        """Get the current pipeline report for use by pipeline code."""
+        return self._current_pipeline

--- a/etl_framework/security/ir.model.access.csv
+++ b/etl_framework/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_etl_import_report,etl.import.report,model_etl_import_report,base.group_system,1,1,1,1
+access_etl_import_report_line,etl.import.report.line,model_etl_import_report_line,base.group_system,1,1,1,1
+access_etl_import_report_detail,etl.import.report.detail,model_etl_import_report_detail,base.group_system,1,1,1,1

--- a/etl_framework/views/etl_import_report_views.xml
+++ b/etl_framework/views/etl_import_report_views.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- ============================================================ -->
+    <!-- etl.import.report -->
+    <!-- ============================================================ -->
+
+    <record id="etl_import_report_tree" model="ir.ui.view">
+        <field name="name">etl.import.report.tree</field>
+        <field name="model">etl.import.report</field>
+        <field name="arch" type="xml">
+            <list decoration-danger="state == 'failed'" decoration-muted="state == 'running'">
+                <field name="name"/>
+                <field name="start_time"/>
+                <field name="duration" widget="float_time"/>
+                <field name="total_success"/>
+                <field name="total_warning"/>
+                <field name="total_failure"/>
+                <field name="state" widget="badge"
+                       decoration-success="state == 'done'"
+                       decoration-danger="state == 'failed'"
+                       decoration-info="state == 'running'"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="etl_import_report_form" model="ir.ui.view">
+        <field name="name">etl.import.report.form</field>
+        <field name="model">etl.import.report</field>
+        <field name="arch" type="xml">
+            <form create="0" edit="0">
+                <header>
+                    <field name="state" widget="statusbar"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1><field name="name"/></h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="start_time"/>
+                            <field name="end_time"/>
+                            <field name="duration" widget="float_time"/>
+                        </group>
+                        <group>
+                            <field name="total_success"/>
+                            <field name="total_warning"/>
+                            <field name="total_failure"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Pipeline Results" name="lines">
+                            <field name="line_ids">
+                                <list decoration-danger="state == 'failed'">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="pipeline_name"/>
+                                    <field name="target_model"/>
+                                    <field name="extracted_count"/>
+                                    <field name="success_count"/>
+                                    <field name="warning_count"/>
+                                    <field name="failure_count"/>
+                                    <field name="duration" widget="float_time"/>
+                                    <field name="state" widget="badge"
+                                           decoration-success="state == 'done'"
+                                           decoration-danger="state == 'failed'"
+                                           decoration-info="state == 'running'"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="etl_import_report_action" model="ir.actions.act_window">
+        <field name="name">ETL Import Reports</field>
+        <field name="res_model">etl.import.report</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <!-- ============================================================ -->
+    <!-- etl.import.report.line -->
+    <!-- ============================================================ -->
+
+    <record id="etl_import_report_line_form" model="ir.ui.view">
+        <field name="name">etl.import.report.line.form</field>
+        <field name="model">etl.import.report.line</field>
+        <field name="arch" type="xml">
+            <form create="0" edit="0">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="pipeline_name"/>
+                            <field name="target_model"/>
+                            <field name="state" widget="badge"
+                                   decoration-success="state == 'done'"
+                                   decoration-danger="state == 'failed'"
+                                   decoration-info="state == 'running'"/>
+                        </group>
+                        <group>
+                            <field name="extracted_count"/>
+                            <field name="success_count"/>
+                            <field name="warning_count"/>
+                            <field name="failure_count"/>
+                            <field name="duration" widget="float_time"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Details" name="details">
+                            <field name="detail_ids">
+                                <list decoration-danger="level == 'failure'"
+                                      decoration-warning="level == 'warning'">
+                                    <field name="level" widget="badge"
+                                           decoration-danger="level == 'failure'"
+                                           decoration-warning="level == 'warning'"/>
+                                    <field name="source_ref"/>
+                                    <field name="message"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- ============================================================ -->
+    <!-- Menu -->
+    <!-- ============================================================ -->
+
+    <menuitem id="etl_menu_root"
+              name="ETL"
+              web_icon="etl_framework,static/description/icon.png"
+              sequence="90"/>
+
+    <menuitem id="etl_menu_reports"
+              name="Import Reports"
+              parent="etl_menu_root"
+              action="etl_import_report_action"
+              sequence="10"/>
+
+</odoo>

--- a/sap_b1_to_odoo/hooks.py
+++ b/sap_b1_to_odoo/hooks.py
@@ -1,48 +1,8 @@
-import logging
-import os
-
-from odoo import SUPERUSER_ID, api
-
-_logger = logging.getLogger(__name__)
-
-
-def _run_sap_import(env):
-    """Run SAP import if SAP_AUTO_IMPORT is enabled."""
-    auto_import = os.getenv("SAP_AUTO_IMPORT", "").lower() in ("1", "true")
-    if not auto_import:
-        return
-
-    _logger.info("SAP_AUTO_IMPORT is enabled, running import_all()")
-
-    # Find the SAP database record created during install
-    sap_db = env["sap.database"].search([], limit=1)
-    if not sap_db:
-        _logger.warning("No sap.database record found, skipping auto-import")
-        return
-
-    try:
-        sap_db._import_all()
-        _logger.info("Successfully completed SAP import")
-    except Exception as e:
-        _logger.error(f"Error during SAP import: {e}", exc_info=True)
-
-
 def post_init_hook(env):
-    """Run SAP import after module installation completes."""
-    _run_sap_import(env)
+    """Post-install hook. No-op.
 
-
-def post_load_hook():
-    """Run SAP import after module update (post_load runs on every load).
-
-    Note: This runs before the registry is fully loaded, so we need to
-    defer the actual import using a post_init_hook pattern.
+    SAP import is triggered manually via odoo-bin shell after all modules
+    are installed, ensuring _inherit overrides from dependent modules are
+    loaded before the import runs.
     """
-    # post_load doesn't have env, so we can't run import here directly.
-    # Instead, we'll use the uninstall_hook approach or rely on post_init.
-    pass
-
-
-def uninstall_hook(env):
-    """Cleanup hook for module uninstall."""
     pass

--- a/sap_b1_to_odoo/models/ir_module.py
+++ b/sap_b1_to_odoo/models/ir_module.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-import os
 
 from odoo import models
 
@@ -11,15 +10,9 @@ class IrModuleModule(models.Model):
     _inherit = "ir.module.module"
 
     def _register_hook(self):
-        """Handle SAP import module registration.
-
-        1. Prevent chart template auto-installation after SAP import
-        2. Run SAP import if SAP_AUTO_IMPORT is enabled (works on both install and update)
-        """
-        # Check if we're in a SAP-imported company
+        """Prevent chart template auto-installation after SAP import."""
         company = self.env.company
         if company:
-            # Check if SAP accounts exist (indicates SAP import has run)
             sap_accounts = self.env["account.account"].search(
                 [("company_ids", "in", [company.id]), ("sap_acct_code", "!=", False)],
                 limit=1,
@@ -30,20 +23,4 @@ class IrModuleModule(models.Model):
                     "SAP CoA detected - chart template already configured or will be set by ETL"
                 )
 
-        # Run SAP import if SAP_AUTO_IMPORT is enabled
-        # This works on both install and update (-u)
-        auto_import = os.getenv("SAP_AUTO_IMPORT", "").lower() in ("1", "true")
-        if auto_import:
-            _logger.info("SAP_AUTO_IMPORT is enabled, running import_all()")
-            sap_db = self.env["sap.database"].search([], limit=1)
-            if sap_db:
-                try:
-                    sap_db._import_all()
-                    _logger.info("Successfully completed SAP import")
-                except Exception as e:
-                    _logger.error(f"Error during SAP import: {e}", exc_info=True)
-            else:
-                _logger.warning("No sap.database record found, skipping auto-import")
-
-        # Proceed with normal hook chain
         return super()._register_hook()

--- a/sap_b1_to_odoo/models/pipelines/account_credit_memo_reconciliation_etl.py
+++ b/sap_b1_to_odoo/models/pipelines/account_credit_memo_reconciliation_etl.py
@@ -210,14 +210,9 @@ class AccountCreditMemoReconciliation(models.AbstractModel):
                     failed += 1
                 continue
 
-            try:
+            with ctx.skippable(f"CM {cm.name} -> {inv.name}"):
                 (cm_line + inv_line).reconcile()
                 reconciled += 1
-            except Exception as e:
-                _logger.warning(
-                    f"Failed to reconcile CM {cm.name} with {inv.name}: {e}"
-                )
-                failed += 1
 
         _logger.info(
             f"[CreditMemoReconciliation] Complete: {reconciled} reconciled, "

--- a/sap_b1_to_odoo/models/pipelines/account_force_paid_etl.py
+++ b/sap_b1_to_odoo/models/pipelines/account_force_paid_etl.py
@@ -302,24 +302,25 @@ class AccountForcePaidReconciliation(models.AbstractModel):
                 ],
             }
 
-            writeoff_move = ctx.env["account.move"].create(writeoff_vals)
-            writeoff_move.action_post()
+            with ctx.skippable(ref):
+                writeoff_move = ctx.env["account.move"].create(writeoff_vals)
+                writeoff_move.action_post()
 
-            # Reconcile with the invoice/bill
-            if doc_type == "customer":
-                writeoff_line = writeoff_move.line_ids.filtered(
-                    lambda l: l.account_id.account_type == "asset_receivable"
-                    and l.credit > 0
-                )
-            else:
-                writeoff_line = writeoff_move.line_ids.filtered(
-                    lambda l: l.account_id.account_type == "liability_payable"
-                    and l.debit > 0
-                )
+                # Reconcile with the invoice/bill
+                if doc_type == "customer":
+                    writeoff_line = writeoff_move.line_ids.filtered(
+                        lambda l: l.account_id.account_type == "asset_receivable"
+                        and l.credit > 0
+                    )
+                else:
+                    writeoff_line = writeoff_move.line_ids.filtered(
+                        lambda l: l.account_id.account_type == "liability_payable"
+                        and l.debit > 0
+                    )
 
-            if writeoff_line and line_to_reconcile:
-                (line_to_reconcile + writeoff_line).reconcile()
-                reconciled_count += 1
+                if writeoff_line and line_to_reconcile:
+                    (line_to_reconcile + writeoff_line).reconcile()
+                    reconciled_count += 1
 
         _logger.info(
             f"[ForcePaidReconciliation] Chunk complete: {reconciled_count} reconciled, "

--- a/sap_b1_to_odoo/models/pipelines/account_internal_reconciliation_etl.py
+++ b/sap_b1_to_odoo/models/pipelines/account_internal_reconciliation_etl.py
@@ -1,18 +1,9 @@
 import logging
 
-import psycopg2
-
 from odoo import api, models
 from odoo.addons.etl_framework import ETL, ETLContext
 
 _logger = logging.getLogger(__name__)
-
-# Errors that should bubble up for retry by the orchestrator
-RETRYABLE_ERRORS = (
-    psycopg2.errors.SerializationFailure,
-    psycopg2.errors.DeadlockDetected,
-    psycopg2.extensions.TransactionRollbackError,
-)
 
 
 @ETL.pipeline(
@@ -364,14 +355,9 @@ class AccountInternalReconciliation(models.AbstractModel):
                 )
 
             if recon_line and line_to_reconcile:
-                try:
+                with ctx.skippable(f"recon move {recon_move.id}"):
                     (line_to_reconcile + recon_line).reconcile()
                     reconciled_count += 1
-                except RETRYABLE_ERRORS:
-                    # Let serialization/deadlock errors bubble up for orchestrator retry
-                    raise
-                except Exception as e:
-                    _logger.warning(f"[InternalReconciliation] Reconcile failed: {e}")
 
         _logger.info(
             f"[InternalReconciliation] Chunk complete: {reconciled_count} reconciled "

--- a/sap_b1_to_odoo/models/pipelines/account_journal_setup.py
+++ b/sap_b1_to_odoo/models/pipelines/account_journal_setup.py
@@ -38,12 +38,11 @@ class AccountJournalSetup(models.AbstractModel):
 
         # Find specific account types
         cash_accounts = accounts.filtered(lambda a: a.account_type == "asset_cash")
-        ar_account = accounts.filtered(lambda a: a.account_type == "asset_receivable")[
-            :1
-        ]
-        ap_account = accounts.filtered(lambda a: a.account_type == "liability_payable")[
-            :1
-        ]
+
+        # Find the most-used AR and AP accounts from SAP business partners (ocrd.debpayacct).
+        # SAP often has per-partner receivable/payable sub-accounts; we want the main ones.
+        ar_account = self._find_most_used_account(ctx, accounts, "asset_receivable")
+        ap_account = self._find_most_used_account(ctx, accounts, "liability_payable")
 
         # Find the most common inventory valuation account from SAP categories
         # Query SAP OITB for the most used balinvntac (inventory account)
@@ -100,6 +99,43 @@ class AccountJournalSetup(models.AbstractModel):
             "stock_valuation_account": stock_valuation_account,
         }
 
+    @api.model
+    def _find_most_used_account(self, ctx, accounts, account_type):
+        """Find the most-used account of a given type from SAP business partners.
+
+        Queries SAP ocrd.debpayacct to find which receivable/payable account
+        is assigned to the most partners, then matches it to an imported Odoo account.
+        Falls back to the first account of that type if no SAP match is found.
+        """
+        ctx.cr.execute(
+            """
+            SELECT a.formatcode, COUNT(*) as cnt
+            FROM ocrd bp
+            JOIN oact a ON bp.debpayacct = a.acctcode
+            WHERE bp.debpayacct IS NOT NULL
+            GROUP BY a.formatcode
+            ORDER BY cnt DESC
+            """
+        )
+        typed_accounts = accounts.filtered(lambda a: a.account_type == account_type)
+        for row in ctx.cr.fetchall():
+            sap_code = row[0]
+            match = typed_accounts.filtered(lambda a, c=sap_code: a.sap_acct_code == c)
+            if match:
+                _logger.info(
+                    f"Most-used {account_type} account from SAP: "
+                    f"{match[0].display_name} ({row[1]} partners)"
+                )
+                return match[0]
+        # Fallback: first account of this type
+        if typed_accounts:
+            _logger.warning(
+                f"No SAP partner match for {account_type}, "
+                f"falling back to {typed_accounts[0].display_name}"
+            )
+            return typed_accounts[0]
+        return ctx.env["account.account"]
+
     @ETL.transform()
     def transform_journals(self, ctx: ETLContext, extracted):
         """Create journal configuration using SAP accounts and archive default journals."""
@@ -141,6 +177,26 @@ class AccountJournalSetup(models.AbstractModel):
                 unused_defaults.write({"active": False})
                 _logger.info(
                     f"Archived {len(unused_defaults)} unused default journals: {', '.join(unused_defaults.mapped('code'))}"
+                )
+
+        # Fix up existing journals whose default_account_id points to an archived account.
+        # This happens when Odoo auto-creates journals (e.g. INV, BILL) with default
+        # accounts that the CoA pipeline later archives in favour of SAP accounts.
+        journal_updates = []
+        for journal in active_journals:
+            if not journal.default_account_id or journal.default_account_id.active:
+                continue
+            replacement = None
+            if journal.type == "sale" and income_account:
+                replacement = income_account
+            elif journal.type == "purchase" and expense_account:
+                replacement = expense_account
+            if replacement:
+                journal_updates.append((journal, replacement))
+                _logger.info(
+                    f"Will re-point {journal.code} default account "
+                    f"from archived {journal.default_account_id.display_name} "
+                    f"to {replacement.display_name}"
                 )
 
         journal_vals = []
@@ -229,6 +285,9 @@ class AccountJournalSetup(models.AbstractModel):
         _logger.info(f"Prepared {len(journal_vals)} journals to create")
         return {
             "journal_vals": journal_vals,
+            "journal_updates": journal_updates,
+            "ar_account": ar_account,
+            "ap_account": ap_account,
             "stock_valuation_account": stock_valuation_account,
         }
 
@@ -237,7 +296,39 @@ class AccountJournalSetup(models.AbstractModel):
         """Create account.journal records and mark chart template as installed."""
         data = transformed.get("transform_journals") or {}
         journal_vals = data.get("journal_vals", [])
+        journal_updates = data.get("journal_updates", [])
         stock_valuation_account = data.get("stock_valuation_account")
+
+        ar_account = data.get("ar_account")
+        ap_account = data.get("ap_account")
+
+        # Set company-wide default receivable/payable accounts via ir.default.
+        # The CoA pipeline archives Odoo's default accounts; without this,
+        # partners inherit the archived defaults and invoice posting fails.
+        IrDefault = ctx.env["ir.default"]
+        if ar_account:
+            IrDefault.set(
+                "res.partner",
+                "property_account_receivable_id",
+                ar_account.id,
+                company_id=ctx.env.company.id,
+            )
+            _logger.info(f"Set default receivable account to {ar_account.display_name}")
+        if ap_account:
+            IrDefault.set(
+                "res.partner",
+                "property_account_payable_id",
+                ap_account.id,
+                company_id=ctx.env.company.id,
+            )
+            _logger.info(f"Set default payable account to {ap_account.display_name}")
+
+        # Re-point journals whose default account was archived by the CoA pipeline
+        for journal, replacement in journal_updates:
+            journal.default_account_id = replacement
+            _logger.info(
+                f"Re-pointed {journal.code} default account to {replacement.display_name}"
+            )
 
         if not journal_vals:
             _logger.info(

--- a/sap_b1_to_odoo/models/pipelines/account_payment_etl.py
+++ b/sap_b1_to_odoo/models/pipelines/account_payment_etl.py
@@ -1,18 +1,9 @@
 import logging
 
-import psycopg2
-
 from odoo import api, models
 from odoo.addons.etl_framework import ETL, ETLContext
 
 _logger = logging.getLogger(__name__)
-
-# Errors that should bubble up for retry by the orchestrator
-RETRYABLE_ERRORS = (
-    psycopg2.errors.SerializationFailure,
-    psycopg2.errors.DeadlockDetected,
-    psycopg2.extensions.TransactionRollbackError,
-)
 
 
 @ETL.pipeline(
@@ -403,14 +394,9 @@ class AccountPaymentReconciliation(models.AbstractModel):
             )
 
             if payment_line and line_to_reconcile:
-                try:
+                with ctx.skippable(f"payment move {payment_move.id}"):
                     (line_to_reconcile + payment_line).reconcile()
                     reconciled_count += 1
-                except RETRYABLE_ERRORS:
-                    # Let serialization/deadlock errors bubble up for orchestrator retry
-                    raise
-                except Exception as e:
-                    _logger.warning(f"[PaymentReconciliation] Reconcile failed: {e}")
 
         _logger.info(
             f"[PaymentReconciliation] Chunk complete: {reconciled_count} reconciled "

--- a/sap_b1_to_odoo/models/pipelines/purchase_order_etl.py
+++ b/sap_b1_to_odoo/models/pipelines/purchase_order_etl.py
@@ -729,7 +729,7 @@ class PurchaseOrderPostProcessor(models.AbstractModel):
         self._set_delivered_qty_for_closed_orders(sap_data.get("closed_orders", []))
 
         _logger.info("Confirming open orders...")
-        self._confirm_open_orders(sap_data.get("open_orders", []))
+        self._confirm_open_orders(ctx, sap_data.get("open_orders", []))
 
         _logger.info("Canceling canceled orders...")
         self._cancel_canceled_orders(sap_data.get("canceled_orders", []))
@@ -788,7 +788,7 @@ class PurchaseOrderPostProcessor(models.AbstractModel):
         self.env.cr.commit()
 
     @api.model
-    def _confirm_open_orders(self, open_orders):
+    def _confirm_open_orders(self, ctx, open_orders):
         """Confirm open orders (creates delivery orders)."""
 
         # Disable automations during confirmation
@@ -802,13 +802,8 @@ class PurchaseOrderPostProcessor(models.AbstractModel):
                 [("sap_docnum", "in", open_orders), ("state", "in", ["draft", "sent"])]
             )
             for order in orders:
-                try:
+                with ctx.skippable(f"confirm PO {order.name}"):
                     order.button_confirm()
-                except Exception as e:
-                    _logger.error(
-                        f"Failed to confirm order {order.name} "
-                        f"(sap_docnum={order.sap_docnum}): {e}"
-                    )
             self.env.cr.commit()
 
         active_automations.active = True

--- a/sap_b1_to_odoo/models/pipelines/sale_order_etl.py
+++ b/sap_b1_to_odoo/models/pipelines/sale_order_etl.py
@@ -772,7 +772,7 @@ class SaleOrderPostProcessor(models.AbstractModel):
         self._set_delivered_qty_for_closed_orders(sap_data.get("closed_orders", []))
 
         _logger.info("Confirming open orders...")
-        self._confirm_open_orders(sap_data.get("open_orders", []))
+        self._confirm_open_orders(ctx, sap_data.get("open_orders", []))
 
         _logger.info("Canceling canceled orders...")
         self._cancel_canceled_orders(sap_data.get("canceled_orders", []))
@@ -829,7 +829,7 @@ class SaleOrderPostProcessor(models.AbstractModel):
         self.env.cr.commit()
 
     @api.model
-    def _confirm_open_orders(self, open_orders):
+    def _confirm_open_orders(self, ctx, open_orders):
         """Confirm open orders (creates delivery orders)."""
 
         # Disable automations during confirmation
@@ -843,13 +843,8 @@ class SaleOrderPostProcessor(models.AbstractModel):
                 [("sap_docnum", "in", open_orders), ("state", "in", ["draft", "sent"])]
             )
             for order in orders:
-                try:
+                with ctx.skippable(f"confirm SO {order.name}"):
                     order.action_confirm()
-                except Exception as e:
-                    _logger.error(
-                        f"Failed to confirm order {order.name} "
-                        f"(sap_docnum={order.sap_docnum}): {e}"
-                    )
             self.env.cr.commit()
 
         active_automations.active = True

--- a/sap_b1_to_odoo/models/sap_database.py
+++ b/sap_b1_to_odoo/models/sap_database.py
@@ -71,7 +71,6 @@ class SapDatabase(models.Model):
         - SAP_DB_PORT: Database port (default: 5432)
         - SAP_DB_SCHEMA: Database schema
         - SAP_FILESTORE_PATH: Filestore path (optional)
-        - SAP_AUTO_IMPORT: Set to '1' or 'true' to auto-run import_all()
         """
         # Check if we should run the setup
         if not os.getenv("SAP_DB_HOST"):
@@ -86,7 +85,6 @@ class SapDatabase(models.Model):
         db_port = int(os.getenv("SAP_DB_PORT", "5432"))
         db_schema = os.getenv("SAP_DB_SCHEMA")
         filestore_path = os.getenv("SAP_FILESTORE_PATH", "")
-        auto_import = os.getenv("SAP_AUTO_IMPORT", "").lower() in ("1", "true")
 
         # Validate required fields
         if not all([db_host, db_name, db_user, db_schema]):
@@ -120,15 +118,9 @@ class SapDatabase(models.Model):
         if existing:
             _logger.info(f"Updating existing sap.database record (ID: {existing.id})")
             existing.write(vals)
-            sap_db = existing
         else:
             _logger.info("Creating new sap.database record")
-            sap_db = self.create(vals)
-
-        if not auto_import:
-            _logger.info(
-                "SAP database record created. Set SAP_AUTO_IMPORT=1 to auto-run import_all()"
-            )
+            self.create(vals)
 
     ##################################################################
     # Public Action Methods (Called from UI)

--- a/test_etl_framework/models/test_importers.py
+++ b/test_etl_framework/models/test_importers.py
@@ -167,3 +167,183 @@ class TestChunkingImporter(models.AbstractModel):
         vals_list = transformed.get("transform_bulk", [])
         if vals_list:
             ctx.env["res.partner.category"].create(vals_list)
+
+
+# =============================================================================
+# Failing Pipeline - For testing uncaught exception reporting
+# =============================================================================
+
+
+@ETL.pipeline(
+    target_model="res.partner.category",
+    importer_name="test.failing.importer",
+    sap_source="test_fail",
+    allow_multiprocessing=False,
+)
+class TestFailingImporter(models.AbstractModel):
+    """Test importer that raises an exception during load."""
+
+    _name = "test.failing.importer"
+    _description = "Test Failing Importer"
+
+    @ETL.extract("test_fail")
+    def extract_data(self, ctx: ETLContext):
+        """Extract test data."""
+        return [{"name": "Will Fail"}]
+
+    @ETL.transform()
+    def transform_data(self, ctx: ETLContext, extracted: dict):
+        """Transform test data."""
+        return extracted.get("extract_data", [])
+
+    @ETL.load()
+    def load_data(self, ctx: ETLContext, transformed: dict):
+        """Load that intentionally fails."""
+        raise RuntimeError("Intentional test failure")
+
+
+# =============================================================================
+# Reporting Pipeline - For testing ctx.report usage
+# =============================================================================
+
+
+@ETL.pipeline(
+    target_model="res.partner.category",
+    importer_name="test.reporting.importer",
+    sap_source="test_report",
+    allow_multiprocessing=False,
+)
+class TestReportingImporter(models.AbstractModel):
+    """Test importer that uses ctx.report to log successes/warnings/failures."""
+
+    _name = "test.reporting.importer"
+    _description = "Test Reporting Importer"
+
+    @ETL.extract("test_report")
+    def extract_data(self, ctx: ETLContext):
+        """Extract test data with some bad records."""
+        return [
+            {"name": "Good 1"},
+            {"name": "Good 2"},
+            {"name": ""},  # Will trigger warning
+            {"name": None},  # Will trigger failure
+        ]
+
+    @ETL.transform()
+    def transform_data(self, ctx: ETLContext, extracted: dict):
+        """Transform, filtering out bad records and reporting."""
+        raw = extracted.get("extract_data", [])
+        result = []
+        for i, item in enumerate(raw):
+            if item.get("name"):
+                result.append({"name": f"[RPT] {item['name']}"})
+            elif item.get("name") == "":
+                ctx.report.warning(
+                    message="Empty name, skipping",
+                    source_ref=f"row-{i}",
+                )
+            else:
+                ctx.report.failure(
+                    message="Null name, cannot import",
+                    source_ref=f"row-{i}",
+                )
+        return result
+
+    @ETL.load()
+    def load_data(self, ctx: ETLContext, transformed: dict):
+        """Load good records and report successes."""
+        vals_list = transformed.get("transform_data", [])
+        if vals_list:
+            records = ctx.env["res.partner.category"].create(vals_list)
+            ctx.report.success(len(records))
+
+
+# =============================================================================
+# Logging Pipeline - For testing auto-capture of log messages
+# =============================================================================
+
+
+@ETL.pipeline(
+    target_model="res.partner.category",
+    importer_name="test.logging.importer",
+    sap_source="test_log",
+    allow_multiprocessing=False,
+)
+class TestLoggingImporter(models.AbstractModel):
+    """Test importer that uses _logger.warning/error during execution."""
+
+    _name = "test.logging.importer"
+    _description = "Test Logging Importer"
+
+    @ETL.extract("test_log")
+    def extract_data(self, ctx: ETLContext):
+        """Extract test data."""
+        return [
+            {"name": "Good"},
+            {"name": "warn_me"},
+            {"name": "error_me"},
+        ]
+
+    @ETL.transform()
+    def transform_data(self, ctx: ETLContext, extracted: dict):
+        """Transform with logged warnings and errors."""
+        raw = extracted.get("extract_data", [])
+        result = []
+        for item in raw:
+            if item["name"] == "warn_me":
+                _logger.warning("Suspicious record: %s", item["name"])
+            elif item["name"] == "error_me":
+                _logger.error("Bad record: %s", item["name"])
+            else:
+                result.append({"name": f"[LOG] {item['name']}"})
+        return result
+
+    @ETL.load()
+    def load_data(self, ctx: ETLContext, transformed: dict):
+        """Load good records."""
+        vals_list = transformed.get("transform_data", [])
+        if vals_list:
+            ctx.env["res.partner.category"].create(vals_list)
+
+
+# =============================================================================
+# Inherit Override Pipeline - For testing _inherit method resolution
+# =============================================================================
+
+
+class TestSimpleImporterOverride(models.AbstractModel):
+    """Inherits test.simple.importer and overrides transform + load.
+
+    Verifies that the ETL framework resolves methods via getattr on the
+    Odoo model instance (respecting _inherit MRO) rather than calling
+    the stored base-class function reference directly.
+    """
+
+    _inherit = "test.simple.importer"
+
+    # Class-level flags set by the override methods
+    _override_transform_called = False
+    _override_load_called = False
+
+    @ETL.transform()
+    def transform_data(self, ctx: ETLContext, extracted: dict):
+        """Override: add a marker to prove this ran instead of the base."""
+        TestSimpleImporterOverride._override_transform_called = True
+        raw_data = extracted.get("extract_data", [])
+        transformed = [{"name": f"[OVERRIDE] {item['name']}"} for item in raw_data]
+        TestSimpleImporter._last_transformed = transformed
+        return transformed
+
+    @ETL.load()
+    def load_data(self, ctx: ETLContext, transformed: dict):
+        """Override: set flag and delegate to create."""
+        TestSimpleImporterOverride._override_load_called = True
+        vals_list = transformed.get("transform_data", [])
+        if vals_list:
+            records = ctx.env["res.partner.category"].create(vals_list)
+            # Store on the base class so existing test helpers still work
+            from odoo.addons.test_etl_framework.models.test_importers import (
+                TestSimpleImporter,
+            )
+
+            TestSimpleImporter._last_loaded_ids = records.ids

--- a/test_etl_framework/tests/__init__.py
+++ b/test_etl_framework/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_etl_pipelines
+from . import test_etl_reporter

--- a/test_etl_framework/tests/test_etl_pipelines.py
+++ b/test_etl_framework/tests/test_etl_pipelines.py
@@ -153,7 +153,7 @@ class TestSimplePipelineExecution(TransactionCase):
             TestSimpleImporter._last_loaded_ids
         )
         self.assertEqual(len(categories), 3)
-        self.assertTrue(all("[TEST" in cat.name for cat in categories))
+        self.assertTrue(all("[OVERRIDE]" in cat.name for cat in categories))
 
 
 @tagged("post_install", "-at_install")
@@ -245,3 +245,92 @@ class TestETLContext(TransactionCase):
         ctx = ETLContext(cr=None, env=self.env)
         partners = ctx.env["res.partner"].search([], limit=1)
         self.assertIsNotNone(partners)
+
+
+@tagged("post_install", "-at_install")
+class TestInheritOverrideResolution(TransactionCase):
+    """Test that _inherit overrides are called by the ETL framework.
+
+    The ETL pipeline decorator stores function references at class
+    registration time. When another module uses _inherit to override
+    those methods, the framework must resolve methods by name on the
+    Odoo model instance (via getattr) so the MRO picks up the override,
+    rather than calling the stored base-class function directly.
+    """
+
+    def setUp(self):
+        super().setUp()
+        from odoo.addons.test_etl_framework.models.test_importers import (
+            TestSimpleImporter,
+            TestSimpleImporterOverride,
+        )
+
+        # Reset class-level state
+        TestSimpleImporter._last_extracted = None
+        TestSimpleImporter._last_transformed = None
+        TestSimpleImporter._last_loaded_ids = None
+        TestSimpleImporterOverride._override_transform_called = False
+        TestSimpleImporterOverride._override_load_called = False
+
+    def test_override_transform_is_called(self):
+        """The _inherit override of transform_data must run, not the base."""
+        from odoo.addons.test_etl_framework.models.test_importers import (
+            TestSimpleImporterOverride,
+        )
+
+        pipeline = ETL.get_pipeline("test.simple.importer")
+        ctx = ETLContext(cr=None, env=self.env)
+        importer = self.env["test.simple.importer"]
+
+        executor = ETLExecutor(pipeline, ctx, importer)
+        executor.execute()
+
+        self.assertTrue(
+            TestSimpleImporterOverride._override_transform_called,
+            "The _inherit override of transform_data was not called. "
+            "The framework is likely calling the stored base-class function "
+            "reference instead of resolving via getattr on the model instance.",
+        )
+
+    def test_override_load_is_called(self):
+        """The _inherit override of load_data must run, not the base."""
+        from odoo.addons.test_etl_framework.models.test_importers import (
+            TestSimpleImporterOverride,
+        )
+
+        pipeline = ETL.get_pipeline("test.simple.importer")
+        ctx = ETLContext(cr=None, env=self.env)
+        importer = self.env["test.simple.importer"]
+
+        executor = ETLExecutor(pipeline, ctx, importer)
+        executor.execute()
+
+        self.assertTrue(
+            TestSimpleImporterOverride._override_load_called,
+            "The _inherit override of load_data was not called. "
+            "The framework is likely calling the stored base-class function "
+            "reference instead of resolving via getattr on the model instance.",
+        )
+
+    def test_override_transform_output_is_used(self):
+        """Records created must reflect the override's transform, not the base."""
+        from odoo.addons.test_etl_framework.models.test_importers import (
+            TestSimpleImporter,
+        )
+
+        pipeline = ETL.get_pipeline("test.simple.importer")
+        ctx = ETLContext(cr=None, env=self.env)
+        importer = self.env["test.simple.importer"]
+
+        executor = ETLExecutor(pipeline, ctx, importer)
+        executor.execute()
+
+        # The override prefixes names with [OVERRIDE], the base uses [CODE]
+        categories = self.env["res.partner.category"].browse(
+            TestSimpleImporter._last_loaded_ids
+        )
+        self.assertTrue(
+            all("[OVERRIDE]" in cat.name for cat in categories),
+            f"Expected [OVERRIDE] prefix from _inherit transform, "
+            f"got names: {categories.mapped('name')}",
+        )

--- a/test_etl_framework/tests/test_etl_reporter.py
+++ b/test_etl_framework/tests/test_etl_reporter.py
@@ -1,0 +1,302 @@
+"""Tests for ETL Reporter functionality.
+
+These tests verify:
+- PipelineReport accumulates successes, warnings, and failures without raising
+- ETLReporter creates and persists report records
+- ETLContext.report property returns a usable report (or no-op)
+- ETLExecutor auto-tracks extracted counts and uncaught exceptions
+- End-to-end reporting through pipeline execution
+"""
+
+from unittest.mock import patch
+
+from odoo.tests import TransactionCase, tagged
+from odoo.tools import mute_logger
+
+from odoo.addons.etl_framework import (
+    ETL,
+    ETLContext,
+    ETLExecutor,
+    PipelineOrchestrator,
+)
+from odoo.addons.etl_framework.reporter import ETLReporter, PipelineReport
+
+
+@tagged("post_install", "-at_install")
+class TestPipelineReport(TransactionCase):
+    """Test the in-memory PipelineReport dataclass."""
+
+    def test_success_increments_count(self):
+        """Calling success() increments the counter."""
+        report = PipelineReport(pipeline_name="test")
+        report.success()
+        report.success(5)
+        self.assertEqual(report.success_count, 6)
+
+    def test_warning_appends_detail(self):
+        """Calling warning() appends a detail and does not raise."""
+        report = PipelineReport(pipeline_name="test")
+        report.warning(message="Missing category", source_ref="ITEM-001")
+        report.warning(message="Duplicate name")
+        self.assertEqual(report.warning_count, 2)
+        self.assertEqual(report.failure_count, 0)
+        self.assertEqual(report.details[0].source_ref, "ITEM-001")
+        self.assertEqual(report.details[0].level, "warning")
+
+    def test_failure_appends_detail_without_raising(self):
+        """Calling failure() appends a detail and does NOT raise."""
+        report = PipelineReport(pipeline_name="test")
+        report.failure(message="Constraint violation", source_ref="DOC-123")
+        report.failure(message="Another error")
+        self.assertEqual(report.failure_count, 2)
+        self.assertEqual(report.warning_count, 0)
+        self.assertEqual(report.details[0].source_ref, "DOC-123")
+        self.assertEqual(report.details[0].level, "failure")
+
+    def test_mixed_details(self):
+        """Warnings and failures coexist correctly."""
+        report = PipelineReport(pipeline_name="test")
+        report.success(10)
+        report.warning(message="w1")
+        report.failure(message="f1")
+        report.warning(message="w2")
+        self.assertEqual(report.success_count, 10)
+        self.assertEqual(report.warning_count, 2)
+        self.assertEqual(report.failure_count, 1)
+
+
+@tagged("post_install", "-at_install")
+class TestETLContextReport(TransactionCase):
+    """Test the ctx.report property."""
+
+    def test_report_without_reporter_returns_noop(self):
+        """ctx.report returns a detached PipelineReport when no reporter is set."""
+        ctx = ETLContext(cr=None, env=self.env)
+        report = ctx.report
+        self.assertIsNotNone(report)
+        self.assertEqual(report.pipeline_name, "_detached")
+        # Should not raise
+        report.success()
+        report.warning(message="test")
+        report.failure(message="test")
+
+    def test_report_with_reporter_returns_current(self):
+        """ctx.report returns the active PipelineReport from the reporter."""
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            reporter.start_run()
+            reporter.start_pipeline(
+                pipeline_name="test.pipeline", target_model="res.partner"
+            )
+            ctx = ETLContext(cr=None, env=self.env, _reporter=reporter)
+            report = ctx.report
+            self.assertEqual(report.pipeline_name, "test.pipeline")
+            report.success(3)
+            self.assertEqual(report.success_count, 3)
+            reporter.end_pipeline(state="done")
+            reporter.end_run(state="done")
+
+
+@tagged("post_install", "-at_install")
+class TestETLReporterPersistence(TransactionCase):
+    """Test that ETLReporter persists results to Odoo models."""
+
+    def test_start_run_creates_report(self):
+        """start_run() creates an etl.import.report record."""
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            report = reporter.start_run()
+            self.assertTrue(report.exists())
+            self.assertEqual(report.state, "running")
+
+    def test_end_run_marks_done(self):
+        """end_run(state='done') sets state and end_time."""
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            reporter.start_run()
+            reporter.end_run(state="done")
+            report = reporter._report_record
+            self.assertEqual(report.state, "done")
+            self.assertTrue(report.end_time)
+
+    def test_end_run_marks_failed(self):
+        """end_run(state='failed') sets state to failed."""
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            reporter.start_run()
+            reporter.end_run(state="failed")
+            report = reporter._report_record
+            self.assertEqual(report.state, "failed")
+
+    def test_pipeline_creates_line(self):
+        """A pipeline start/end cycle creates a report line."""
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            reporter.start_run()
+            reporter.start_pipeline(
+                pipeline_name="test.importer", target_model="product.product"
+            )
+            reporter.current.extracted_count = 100
+            reporter.current.success(95)
+            reporter.current.warning(message="Missing field", source_ref="ITEM-1")
+            reporter.current.failure(message="Constraint error", source_ref="ITEM-2")
+            reporter.end_pipeline(state="done")
+            reporter.end_run(state="done")
+
+            report = reporter._report_record
+            self.assertEqual(len(report.line_ids), 1)
+
+            line = report.line_ids
+            self.assertEqual(line.pipeline_name, "test.importer")
+            self.assertEqual(line.target_model, "product.product")
+            self.assertEqual(line.extracted_count, 100)
+            self.assertEqual(line.success_count, 95)
+            self.assertEqual(line.warning_count, 1)
+            self.assertEqual(line.failure_count, 1)
+            self.assertEqual(line.state, "done")
+
+            # Check details
+            self.assertEqual(len(line.detail_ids), 2)
+            warning_detail = line.detail_ids.filtered(lambda d: d.level == "warning")
+            failure_detail = line.detail_ids.filtered(lambda d: d.level == "failure")
+            self.assertEqual(warning_detail.source_ref, "ITEM-1")
+            self.assertEqual(failure_detail.source_ref, "ITEM-2")
+
+    def test_multiple_pipelines(self):
+        """Multiple pipelines create multiple lines with correct totals."""
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            reporter.start_run()
+
+            reporter.start_pipeline(pipeline_name="pipeline.a", target_model="model.a")
+            reporter.current.success(10)
+            reporter.current.warning(message="w1")
+            reporter.end_pipeline(state="done")
+
+            reporter.start_pipeline(pipeline_name="pipeline.b", target_model="model.b")
+            reporter.current.success(20)
+            reporter.current.failure(message="f1")
+            reporter.current.failure(message="f2")
+            reporter.end_pipeline(state="done")
+
+            reporter.end_run(state="done")
+
+            report = reporter._report_record
+            self.assertEqual(len(report.line_ids), 2)
+            self.assertEqual(report.total_success, 30)
+            self.assertEqual(report.total_warning, 1)
+            self.assertEqual(report.total_failure, 2)
+
+
+@tagged("post_install", "-at_install")
+class TestExecutorReporting(TransactionCase):
+    """Test that ETLExecutor auto-tracks reporting."""
+
+    def test_executor_auto_tracks_extracted_count(self):
+        """ETLExecutor records extracted_count on the pipeline report."""
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            reporter.start_run()
+
+            pipeline = ETL.get_pipeline("test.simple.importer")
+            ctx = ETLContext(cr=None, env=self.env, _reporter=reporter)
+            importer = self.env["test.simple.importer"]
+
+            executor = ETLExecutor(pipeline, ctx, importer)
+            executor.execute()
+
+            reporter.end_run(state="done")
+
+            report = reporter._report_record
+            self.assertEqual(len(report.line_ids), 1)
+            line = report.line_ids
+            self.assertEqual(line.extracted_count, 3)
+            self.assertEqual(line.state, "done")
+
+    @mute_logger("odoo.addons.etl_framework.framework")
+    def test_executor_records_uncaught_exception(self):
+        """ETLExecutor records uncaught exceptions as failures.
+
+        We capture the in-memory PipelineReport via a patched end_pipeline
+        because TransactionCase rolls back the savepoint on exception,
+        which undoes DB records created in the executor's finally block.
+        """
+        captured_reports = []
+        original_end = ETLReporter.end_pipeline
+
+        def capturing_end(reporter_self, state="done"):
+            captured_reports.append((reporter_self.current, state))
+            original_end(reporter_self, state=state)
+
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            reporter.start_run()
+
+            pipeline = ETL.get_pipeline("test.failing.importer")
+            ctx = ETLContext(cr=None, env=self.env, _reporter=reporter)
+            importer = self.env["test.failing.importer"]
+
+            executor = ETLExecutor(pipeline, ctx, importer)
+            with patch.object(ETLReporter, "end_pipeline", capturing_end):
+                with self.assertRaises(RuntimeError):
+                    executor.execute()
+
+            # Verify the in-memory report captured the failure
+            self.assertEqual(len(captured_reports), 1)
+            in_memory_report, state = captured_reports[0]
+            self.assertEqual(state, "failed")
+            self.assertEqual(in_memory_report.failure_count, 1)
+            self.assertIn(
+                "Intentional test failure", in_memory_report.details[0].message
+            )
+
+    def test_pipeline_reports_via_ctx(self):
+        """Pipeline code can use ctx.report to log successes/warnings/failures."""
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            reporter.start_run()
+
+            pipeline = ETL.get_pipeline("test.reporting.importer")
+            ctx = ETLContext(cr=None, env=self.env, _reporter=reporter)
+            importer = self.env["test.reporting.importer"]
+
+            executor = ETLExecutor(pipeline, ctx, importer)
+            executor.execute()
+
+            reporter.end_run(state="done")
+
+            report = reporter._report_record
+            line = report.line_ids
+            self.assertEqual(line.success_count, 2)
+            self.assertEqual(line.warning_count, 1)
+            self.assertEqual(line.failure_count, 1)
+            # Pipeline should NOT have raised despite the failure
+            self.assertEqual(line.state, "done")
+
+    def test_logged_warnings_and_errors_auto_captured(self):
+        """_logger.warning() and _logger.error() in pipelines are auto-captured."""
+        with patch.object(self.env.cr, "commit", lambda: None):
+            reporter = ETLReporter(self.env)
+            reporter.start_run()
+
+            pipeline = ETL.get_pipeline("test.logging.importer")
+            ctx = ETLContext(cr=None, env=self.env, _reporter=reporter)
+            importer = self.env["test.logging.importer"]
+
+            executor = ETLExecutor(pipeline, ctx, importer)
+            executor.execute()
+
+            reporter.end_run(state="done")
+
+            report = reporter._report_record
+            line = report.line_ids
+            # 1 warning from _logger.warning, 1 failure from _logger.error
+            self.assertEqual(line.warning_count, 1)
+            self.assertEqual(line.failure_count, 1)
+
+            warning_detail = line.detail_ids.filtered(lambda d: d.level == "warning")
+            failure_detail = line.detail_ids.filtered(lambda d: d.level == "failure")
+            self.assertIn("Suspicious record", warning_detail.message)
+            self.assertIn("(logged:", warning_detail.source_ref)
+            self.assertIn("Bad record", failure_detail.message)
+            self.assertIn("(logged:", failure_detail.source_ref)


### PR DESCRIPTION
## Summary

- Add `ETLReporter` and `PipelineReport` classes to track pipeline run state, extracted record counts, per-record successes/warnings/failures, and elapsed time
- Add `etl.import.report` Odoo model with list/form views surfacing all of the above in the UI
- Add `ReportLogHandler` to auto-capture WARNING+ log messages into the active pipeline report
- Fix multiprocessing connection pool corruption: replace `db_connect` with `Registry.cursor()` in `_process_chunk_static` and add explicit `cr._cnx.rollback()` on failure to avoid dirty connections after fork
- Improve chunk-level retry logic in `_execute_parallel` to inspect the full exception chain (`_find_retryable_db_error`) instead of only catching `RETRYABLE_DB_ERRORS` directly
- Rename `RETRYABLE_ERRORS` → `RETRYABLE_DB_ERRORS` for clarity
- Add `ActiveSqlTransaction` to retryable error set as a safety net
- Cap multiprocessing worker count at `min(get_workers(), len(chunks))`
- Add `test_etl_reporter.py` with comprehensive reporter tests

## Test plan

- [ ] Run `test_etl_framework` test suite — all existing + new reporter tests pass
- [ ] Trigger a pipeline run and verify the `ETL Import Reports` menu shows run time, extracted count, warnings and failures
- [ ] Trigger a pipeline with a deliberate per-record failure inside `ctx.skippable()` and confirm it appears as a warning row on the report rather than crashing the run
- [ ] Verify multiprocessing path works without `DISCARD ALL cannot run inside a transaction block` errors in the logs