### PR TITLE
fix(qbo): shipping, discounts, deposit balance

### DIFF
--- a/qbo_to_odoo/models/pipelines/credit_memo_etl.py
+++ b/qbo_to_odoo/models/pipelines/credit_memo_etl.py
@@ -62,6 +62,17 @@ class QboCreditMemoImporter(models.AbstractModel):
         )
         extractor.preload_journals("sale")
 
+        # Resolve shipping account from QBO Preferences
+        api_client = get_api_client(ctx)
+        prefs = api_client.query("Preferences", max_results=1)
+        if prefs:
+            ship_qbo_id = (prefs[0] if isinstance(prefs, list) else prefs
+                           ).get("SalesFormsPrefs", {}).get("DefaultShippingAccount")
+            if ship_qbo_id:
+                extractor.extra["shipping_account_id"] = extractor.account_map.get(
+                    int(ship_qbo_id)
+                )
+
         return ChunkableData(
             records=new_credit_memos,
             context={"extractor": extractor.export()},
@@ -88,7 +99,7 @@ class QboCreditMemoImporter(models.AbstractModel):
                 journal_type="sale",
                 partner_type="customer",
                 qbo_id_field="qbo_credit_memo_id",
-                line_detail_types=("SalesItemLineDetail",),
+                line_detail_types=("SalesItemLineDetail", "DiscountLineDetail"),
                 tax_use="sale",
                 direction="income",
                 memo_field="CustomerMemo",

--- a/qbo_to_odoo/models/pipelines/deposit_etl.py
+++ b/qbo_to_odoo/models/pipelines/deposit_etl.py
@@ -245,10 +245,12 @@ class QboDepositImporter(models.AbstractModel):
         )
         line_ids.extend(tax_line_tuples)
 
-        # Debit line for bank account (DepositToAccountRef)
-        debit_company = builder.convert_to_company_currency(
-            total_amt, exchange_rate, is_foreign
-        )
+        # Debit line for bank account — computed from actual line totals
+        # rather than TotalAmt, which may include linked transactions
+        # (e.g. TaxPayment refunds) with no DepositLineDetail.
+        total_credits = sum(l[2].get("credit", 0) for l in line_ids)
+        total_debits = sum(l[2].get("debit", 0) for l in line_ids)
+        debit_company = total_credits - total_debits
         debit_line_vals = {
             "account_id": deposit_to_account_id,
             "name": f"Deposit to {deposit_to_ref.get('name', 'bank')}",
@@ -256,8 +258,17 @@ class QboDepositImporter(models.AbstractModel):
             "credit": 0,
         }
         if is_foreign:
+            # Compute foreign amount from lines rather than TotalAmt
+            fc_credits = sum(
+                abs(l[2].get("amount_currency", 0))
+                for l in line_ids if l[2].get("credit", 0) > 0
+            )
+            fc_debits = sum(
+                abs(l[2].get("amount_currency", 0))
+                for l in line_ids if l[2].get("debit", 0) > 0
+            )
             debit_line_vals["currency_id"] = currency_id
-            debit_line_vals["amount_currency"] = total_amt
+            debit_line_vals["amount_currency"] = fc_credits - fc_debits
 
         line_ids.append((0, 0, debit_line_vals))
         return line_ids

--- a/qbo_to_odoo/models/pipelines/invoice_etl.py
+++ b/qbo_to_odoo/models/pipelines/invoice_etl.py
@@ -68,6 +68,17 @@ class QboInvoiceImporter(models.AbstractModel):
         )
         extractor.preload_journals("sale")
 
+        # Resolve shipping account from QBO Preferences
+        api_client = get_api_client(ctx)
+        prefs = api_client.query("Preferences", max_results=1)
+        if prefs:
+            ship_qbo_id = (prefs[0] if isinstance(prefs, list) else prefs
+                           ).get("SalesFormsPrefs", {}).get("DefaultShippingAccount")
+            if ship_qbo_id:
+                extractor.extra["shipping_account_id"] = extractor.account_map.get(
+                    int(ship_qbo_id)
+                )
+
         # Pipeline-specific: estimate lookup for linking invoices to sale orders
         extractor.extra["estimate_map"] = extractor.qbo_id_map(
             "sale_order", "qbo_estimate_id"
@@ -104,7 +115,7 @@ class QboInvoiceImporter(models.AbstractModel):
                 journal_type="sale",
                 partner_type="customer",
                 qbo_id_field="qbo_invoice_id",
-                line_detail_types=("SalesItemLineDetail",),
+                line_detail_types=("SalesItemLineDetail", "DiscountLineDetail"),
                 tax_use="sale",
                 direction="income",
                 memo_field="CustomerMemo",

--- a/qbo_to_odoo/models/pipelines/move_builder.py
+++ b/qbo_to_odoo/models/pipelines/move_builder.py
@@ -454,6 +454,10 @@ class QBOMoveBuilder:
             return self._build_sales_item_invoice_line(
                 line, detail, entry, tax_use, direction, force_positive
             )
+        elif detail_type == "DiscountLineDetail":
+            return self._build_discount_invoice_line(
+                line, detail, entry, tax_use
+            )
         elif detail_type == "ItemBasedExpenseLineDetail":
             return self._build_item_expense_invoice_line(
                 line, detail, entry, tax_use, force_positive
@@ -467,8 +471,16 @@ class QBOMoveBuilder:
     def _build_sales_item_invoice_line(
         self, line, detail, entry, tax_use, direction, force_positive
     ) -> Optional[Dict]:
-        product_id = self.resolve_product(detail)
-        account_id = self.resolve_account(detail, product_id, direction)
+        item_ref = detail.get("ItemRef", {})
+        # QBO uses the magic value "SHIPPING_ITEM_ID" for shipping lines.
+        # These have no ItemAccountRef and can't resolve to a product.
+        # Look up the shipping account from QBO's Item.IncomeAccountRef.
+        is_shipping = item_ref.get("value") == "SHIPPING_ITEM_ID"
+        product_id = None if is_shipping else self.resolve_product(detail)
+        if is_shipping:
+            account_id = self.get_extra("shipping_account_id")
+        else:
+            account_id = self.resolve_account(detail, product_id, direction)
         qty = float(detail.get("Qty", 1) or 1)
         unit_price = float(detail.get("UnitPrice", 0) or 0)
         amount = float(line.get("Amount", 0) or 0)
@@ -477,7 +489,6 @@ class QBOMoveBuilder:
         if force_positive:
             unit_price = abs(unit_price)
         tax_ids = self.resolve_tax(detail, entry, tax_use)
-        item_ref = detail.get("ItemRef", {})
         line_vals = {
             "name": line.get("Description", "") or item_ref.get("name", "") or "/",
             "quantity": qty,
@@ -485,6 +496,40 @@ class QBOMoveBuilder:
         }
         if product_id:
             line_vals["product_id"] = product_id
+        if account_id:
+            line_vals["account_id"] = account_id
+        if tax_ids:
+            line_vals["tax_ids"] = [(6, 0, tax_ids)]
+        return line_vals
+
+    def _build_discount_invoice_line(
+        self, line, detail, entry, tax_use
+    ) -> Optional[Dict]:
+        """Build an invoice line for a QBO DiscountLineDetail.
+
+        QBO discounts have a DiscountAccountRef and may be percentage
+        or fixed amount.  They create a negative (contra-revenue) line.
+        """
+        amount = float(line.get("Amount", 0) or 0)
+        if amount == 0:
+            return None
+
+        # Resolve discount account from DiscountAccountRef
+        account_ref = detail.get("DiscountAccountRef", {})
+        account_id = None
+        if account_ref and account_ref.get("value"):
+            try:
+                account_id = self.account_map.get(int(account_ref["value"]))
+            except (ValueError, TypeError):
+                pass
+
+        tax_ids = self.resolve_tax(detail, entry, tax_use)
+
+        line_vals = {
+            "name": line.get("Description", "") or "Discount",
+            "quantity": 1,
+            "price_unit": -abs(amount),  # Negative for contra-revenue
+        }
         if account_id:
             line_vals["account_id"] = account_id
         if tax_ids:


### PR DESCRIPTION
## Summary
- Handle SHIPPING_ITEM_ID → 4007 Other Income ($106K fix)
- Add DiscountLineDetail for invoices/credit memos ($33K fix)
- Fix deposit bank debit to use line totals not TotalAmt ($11K fix)

**Not yet tested in a full run** — committed to preserve code, needs restart + re-import to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)