### PR TITLE
fix(partner_etl): backfill addresses in linker + update paths, harden country alias (task #3200)

### DIFF
--- a/qbo_to_odoo/models/pipelines/partner_etl.py
+++ b/qbo_to_odoo/models/pipelines/partner_etl.py
@@ -148,20 +148,53 @@ class QboCustomerImporter(models.AbstractModel):
         return partner_vals
 
     def _get_country_id(self, ctx: ETLContext, country_code: str) -> int:
-        """Get Odoo country ID from country code."""
+        """Get Odoo country ID from country code.
+
+        Applies an explicit alias map for common 3-letter codes (e.g. "USA"→"US",
+        "CAN"→"CA") before falling back to a name lookup.  The name fallback uses
+        ``=ilike`` (case-insensitive exact match) and only applies to strings longer
+        than 3 characters to prevent short ISO-alpha-3 codes from fuzzy-matching
+        unrelated country names (e.g. "USA" matching "United States Minor Outlying
+        Islands").
+        """
         if not country_code:
             return False
 
-        country = ctx.env["res.country"].search(
-            [
-                "|",
-                ("code", "=", country_code),
-                ("name", "ilike", country_code),
-            ],
-            limit=1,
-        )
+        # Explicit alias map: alpha-3 codes and other common variants
+        _COUNTRY_ALIAS = {
+            "USA": "US",
+            "CAN": "CA",
+            "MEX": "MX",
+            "GBR": "GB",
+            "FRA": "FR",
+            "DEU": "DE",
+            "ITA": "IT",
+            "ESP": "ES",
+            "CHN": "CN",
+            "JPN": "JP",
+            "AUS": "AU",
+            "BRA": "BR",
+            "IND": "IN",
+            "RUS": "RU",
+            "ZAF": "ZA",
+        }
+        resolved = _COUNTRY_ALIAS.get(country_code.upper(), country_code)
 
-        return country.id if country else False
+        # Try exact ISO-2 code match first
+        country = ctx.env["res.country"].search(
+            [("code", "=", resolved)], limit=1
+        )
+        if country:
+            return country.id
+
+        # Name fallback: only for strings longer than 3 chars (avoids alpha-3 collisions)
+        if len(resolved) > 3:
+            country = ctx.env["res.country"].search(
+                [("name", "=ilike", resolved)], limit=1
+            )
+            return country.id if country else False
+
+        return False
 
     def _get_state_id(self, ctx: ETLContext, state_code: str, country_code: str) -> int:
         """Get Odoo state ID from state and country codes."""
@@ -333,20 +366,53 @@ class QboVendorImporter(models.AbstractModel):
         return partner_vals
 
     def _get_country_id(self, ctx: ETLContext, country_code: str) -> int:
-        """Get Odoo country ID from country code."""
+        """Get Odoo country ID from country code.
+
+        Applies an explicit alias map for common 3-letter codes (e.g. "USA"→"US",
+        "CAN"→"CA") before falling back to a name lookup.  The name fallback uses
+        ``=ilike`` (case-insensitive exact match) and only applies to strings longer
+        than 3 characters to prevent short ISO-alpha-3 codes from fuzzy-matching
+        unrelated country names (e.g. "USA" matching "United States Minor Outlying
+        Islands").
+        """
         if not country_code:
             return False
 
-        country = ctx.env["res.country"].search(
-            [
-                "|",
-                ("code", "=", country_code),
-                ("name", "ilike", country_code),
-            ],
-            limit=1,
-        )
+        # Explicit alias map: alpha-3 codes and other common variants
+        _COUNTRY_ALIAS = {
+            "USA": "US",
+            "CAN": "CA",
+            "MEX": "MX",
+            "GBR": "GB",
+            "FRA": "FR",
+            "DEU": "DE",
+            "ITA": "IT",
+            "ESP": "ES",
+            "CHN": "CN",
+            "JPN": "JP",
+            "AUS": "AU",
+            "BRA": "BR",
+            "IND": "IN",
+            "RUS": "RU",
+            "ZAF": "ZA",
+        }
+        resolved = _COUNTRY_ALIAS.get(country_code.upper(), country_code)
 
-        return country.id if country else False
+        # Try exact ISO-2 code match first
+        country = ctx.env["res.country"].search(
+            [("code", "=", resolved)], limit=1
+        )
+        if country:
+            return country.id
+
+        # Name fallback: only for strings longer than 3 chars (avoids alpha-3 collisions)
+        if len(resolved) > 3:
+            country = ctx.env["res.country"].search(
+                [("name", "=ilike", resolved)], limit=1
+            )
+            return country.id if country else False
+
+        return False
 
     def _get_state_id(self, ctx: ETLContext, state_code: str, country_code: str) -> int:
         """Get Odoo state ID from state and country codes."""
@@ -429,10 +495,18 @@ class QboCustomerLinker(models.AbstractModel):
         for customer in customers:
             name = customer.get("DisplayName") or customer.get("CompanyName") or ""
             if name and name.lower() in partner_by_name:
+                bill_addr = customer.get("BillAddr", {}) or {}
                 update = {
                     "partner_id": partner_by_name[name.lower()],
                     "qbo_customer_id": int(customer.get("Id")),
                     "name": name,
+                    # Address fields for backfill (only written when target is empty)
+                    "addr_street": bill_addr.get("Line1"),
+                    "addr_street2": bill_addr.get("Line2"),
+                    "addr_city": bill_addr.get("City"),
+                    "addr_zip": bill_addr.get("PostalCode"),
+                    "addr_country_code": bill_addr.get("Country"),
+                    "addr_state_code": bill_addr.get("CountrySubDivisionCode"),
                 }
 
                 # Payment terms
@@ -449,7 +523,7 @@ class QboCustomerLinker(models.AbstractModel):
 
     @ETL.load()
     def load_customer_links(self, ctx: ETLContext, transformed: Dict) -> None:
-        """Update existing partners with QBO customer IDs and payment terms."""
+        """Update existing partners with QBO customer IDs, payment terms, and address (backfill only)."""
         link_updates = transformed.get("transform_customers_for_linking", [])
 
         if not link_updates:
@@ -465,6 +539,27 @@ class QboCustomerLinker(models.AbstractModel):
             }
             if "property_payment_term_id" in update:
                 vals["property_payment_term_id"] = update["property_payment_term_id"]
+
+            # Backfill address fields that are currently empty (per-field guard)
+            if not partner.street and update.get("addr_street"):
+                vals["street"] = update["addr_street"]
+            if not partner.street2 and update.get("addr_street2"):
+                vals["street2"] = update["addr_street2"]
+            if not partner.city and update.get("addr_city"):
+                vals["city"] = update["addr_city"]
+            if not partner.zip and update.get("addr_zip"):
+                vals["zip"] = update["addr_zip"]
+            if not partner.country_id and update.get("addr_country_code"):
+                country_id = self._get_country_id(ctx, update["addr_country_code"])
+                if country_id:
+                    vals["country_id"] = country_id
+            if not partner.state_id and update.get("addr_state_code"):
+                state_id = self._get_state_id(
+                    ctx, update["addr_state_code"], update.get("addr_country_code")
+                )
+                if state_id:
+                    vals["state_id"] = state_id
+
             partner.write(vals)
 
             _logger.debug(
@@ -473,6 +568,50 @@ class QboCustomerLinker(models.AbstractModel):
             )
 
         _logger.info(f"Linked {len(link_updates)} existing partners to QBO customers")
+
+    def _get_country_id(self, ctx: ETLContext, country_code: str) -> int:
+        """Get Odoo country ID from country code with alias map and tightened name fallback."""
+        if not country_code:
+            return False
+
+        _COUNTRY_ALIAS = {
+            "USA": "US",
+            "CAN": "CA",
+            "MEX": "MX",
+            "GBR": "GB",
+            "FRA": "FR",
+            "DEU": "DE",
+            "ITA": "IT",
+            "ESP": "ES",
+            "CHN": "CN",
+            "JPN": "JP",
+            "AUS": "AU",
+            "BRA": "BR",
+            "IND": "IN",
+            "RUS": "RU",
+            "ZAF": "ZA",
+        }
+        resolved = _COUNTRY_ALIAS.get(country_code.upper(), country_code)
+        country = ctx.env["res.country"].search([("code", "=", resolved)], limit=1)
+        if country:
+            return country.id
+        if len(resolved) > 3:
+            country = ctx.env["res.country"].search(
+                [("name", "=ilike", resolved)], limit=1
+            )
+            return country.id if country else False
+        return False
+
+    def _get_state_id(self, ctx: ETLContext, state_code: str, country_code: str) -> int:
+        """Get Odoo state ID from state and country codes."""
+        if not state_code:
+            return False
+        country_id = self._get_country_id(ctx, country_code)
+        domain = [("code", "=", state_code)]
+        if country_id:
+            domain.append(("country_id", "=", country_id))
+        state = ctx.env["res.country.state"].search(domain, limit=1)
+        return state.id if state else False
 
 
 @ETL.pipeline(
@@ -528,10 +667,18 @@ class QboVendorLinker(models.AbstractModel):
         for vendor in vendors:
             name = vendor.get("DisplayName") or vendor.get("CompanyName") or ""
             if name and name.lower() in partner_by_name:
+                bill_addr = vendor.get("BillAddr", {}) or {}
                 update = {
                     "partner_id": partner_by_name[name.lower()],
                     "qbo_vendor_id": int(vendor.get("Id")),
                     "name": name,
+                    # Address fields for backfill (only written when target is empty)
+                    "addr_street": bill_addr.get("Line1"),
+                    "addr_street2": bill_addr.get("Line2"),
+                    "addr_city": bill_addr.get("City"),
+                    "addr_zip": bill_addr.get("PostalCode"),
+                    "addr_country_code": bill_addr.get("Country"),
+                    "addr_state_code": bill_addr.get("CountrySubDivisionCode"),
                 }
 
                 # Payment terms
@@ -559,7 +706,7 @@ class QboVendorLinker(models.AbstractModel):
 
     @ETL.load()
     def load_vendor_links(self, ctx: ETLContext, transformed: Dict) -> None:
-        """Update existing partners with QBO vendor IDs, payment terms, and currency."""
+        """Update existing partners with QBO vendor IDs, payment terms, currency, and address (backfill only)."""
         link_updates = transformed.get("transform_vendors_for_linking", [])
 
         if not link_updates:
@@ -577,6 +724,27 @@ class QboVendorLinker(models.AbstractModel):
                 vals["property_supplier_payment_term_id"] = update["property_supplier_payment_term_id"]
             if "property_purchase_currency_id" in update:
                 vals["property_purchase_currency_id"] = update["property_purchase_currency_id"]
+
+            # Backfill address fields that are currently empty (per-field guard)
+            if not partner.street and update.get("addr_street"):
+                vals["street"] = update["addr_street"]
+            if not partner.street2 and update.get("addr_street2"):
+                vals["street2"] = update["addr_street2"]
+            if not partner.city and update.get("addr_city"):
+                vals["city"] = update["addr_city"]
+            if not partner.zip and update.get("addr_zip"):
+                vals["zip"] = update["addr_zip"]
+            if not partner.country_id and update.get("addr_country_code"):
+                country_id = self._get_country_id(ctx, update["addr_country_code"])
+                if country_id:
+                    vals["country_id"] = country_id
+            if not partner.state_id and update.get("addr_state_code"):
+                state_id = self._get_state_id(
+                    ctx, update["addr_state_code"], update.get("addr_country_code")
+                )
+                if state_id:
+                    vals["state_id"] = state_id
+
             partner.write(vals)
 
             _logger.debug(
@@ -585,3 +753,47 @@ class QboVendorLinker(models.AbstractModel):
             )
 
         _logger.info(f"Linked {len(link_updates)} existing partners to QBO vendors")
+
+    def _get_country_id(self, ctx: ETLContext, country_code: str) -> int:
+        """Get Odoo country ID from country code with alias map and tightened name fallback."""
+        if not country_code:
+            return False
+
+        _COUNTRY_ALIAS = {
+            "USA": "US",
+            "CAN": "CA",
+            "MEX": "MX",
+            "GBR": "GB",
+            "FRA": "FR",
+            "DEU": "DE",
+            "ITA": "IT",
+            "ESP": "ES",
+            "CHN": "CN",
+            "JPN": "JP",
+            "AUS": "AU",
+            "BRA": "BR",
+            "IND": "IN",
+            "RUS": "RU",
+            "ZAF": "ZA",
+        }
+        resolved = _COUNTRY_ALIAS.get(country_code.upper(), country_code)
+        country = ctx.env["res.country"].search([("code", "=", resolved)], limit=1)
+        if country:
+            return country.id
+        if len(resolved) > 3:
+            country = ctx.env["res.country"].search(
+                [("name", "=ilike", resolved)], limit=1
+            )
+            return country.id if country else False
+        return False
+
+    def _get_state_id(self, ctx: ETLContext, state_code: str, country_code: str) -> int:
+        """Get Odoo state ID from state and country codes."""
+        if not state_code:
+            return False
+        country_id = self._get_country_id(ctx, country_code)
+        domain = [("code", "=", state_code)]
+        if country_id:
+            domain.append(("country_id", "=", country_id))
+        state = ctx.env["res.country.state"].search(domain, limit=1)
+        return state.id if state else False

--- a/qbo_to_odoo/tests/__init__.py
+++ b/qbo_to_odoo/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_payment_fx_rate
+from . import test_partner_etl_addresses

--- a/qbo_to_odoo/tests/test_partner_etl_addresses.py
+++ b/qbo_to_odoo/tests/test_partner_etl_addresses.py
@@ -76,7 +76,7 @@ def _stub_qbo_vendor(
     }
 
 
-@tagged("post_install", "-at_install")
+@tagged("post_install", "-at_install", "partner_address_etl")
 class TestQboCustomerLinkerAddressBackfill(TransactionCase):
     """AC1 & AC2: customer linker backfills empty address, skips populated address."""
 
@@ -177,7 +177,7 @@ class TestQboCustomerLinkerAddressBackfill(TransactionCase):
                          "Street must not change on second run")
 
 
-@tagged("post_install", "-at_install")
+@tagged("post_install", "-at_install", "partner_address_etl")
 class TestQboCountryAliasResolution(TransactionCase):
     """AC3: create path resolves 'USA' → country_id.code == 'US'."""
 
@@ -219,7 +219,7 @@ class TestQboCountryAliasResolution(TransactionCase):
         self.assertEqual(country_id, us_country.id)
 
 
-@tagged("post_install", "-at_install")
+@tagged("post_install", "-at_install", "partner_address_etl")
 class TestQboVendorLinkerAddressBackfill(TransactionCase):
     """AC4: vendor linker backfills address on empty partner."""
 

--- a/qbo_to_odoo/tests/test_partner_etl_addresses.py
+++ b/qbo_to_odoo/tests/test_partner_etl_addresses.py
@@ -1,0 +1,266 @@
+"""Tests for QBO partner ETL address backfill and country-code resolution.
+
+Acceptance criteria:
+1. QboCustomerLinker backfills all six address fields on an empty partner and sets
+   qbo_customer_id.
+2. QboCustomerLinker does NOT overwrite address fields already set on the partner;
+   only qbo_customer_id (and payment-term if present) are written.
+3. QboCustomerImporter (create path) resolves BillAddr.Country="USA" to country_id
+   with code=="US", not "UM" or any other wrong match.
+4. QboVendorLinker backfills address on an empty partner (analogous to AC1).
+5. Re-running the linker on a partner that now has a full address is a no-op on
+   address fields (idempotent backfill).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.etl_framework import ETLContext
+
+
+def _make_ctx(env):
+    """Build a minimal ETLContext backed by the Odoo test env."""
+    return ETLContext(cr=None, env=env)
+
+
+def _stub_qbo_customer(
+    qbo_id="1",
+    name="Test Corp",
+    line1="1 Main St",
+    line2=None,
+    city="Austin",
+    state="TX",
+    country="USA",
+    postal="78701",
+):
+    return {
+        "Id": qbo_id,
+        "DisplayName": name,
+        "CompanyName": name,
+        "Active": True,
+        "BillAddr": {
+            "Line1": line1,
+            "Line2": line2,
+            "City": city,
+            "CountrySubDivisionCode": state,
+            "Country": country,
+            "PostalCode": postal,
+        },
+    }
+
+
+def _stub_qbo_vendor(
+    qbo_id="10",
+    name="Test Vendor LLC",
+    line1="99 Supplier Ave",
+    line2=None,
+    city="Dallas",
+    state="TX",
+    country="USA",
+    postal="75201",
+):
+    return {
+        "Id": qbo_id,
+        "DisplayName": name,
+        "CompanyName": name,
+        "Active": True,
+        "BillAddr": {
+            "Line1": line1,
+            "Line2": line2,
+            "City": city,
+            "CountrySubDivisionCode": state,
+            "Country": country,
+            "PostalCode": postal,
+        },
+    }
+
+
+@tagged("post_install", "-at_install")
+class TestQboCustomerLinkerAddressBackfill(TransactionCase):
+    """AC1 & AC2: customer linker backfills empty address, skips populated address."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.us_country = cls.env.ref("base.us")
+        cls.tx_state = cls.env["res.country.state"].search(
+            [("code", "=", "TX"), ("country_id", "=", cls.us_country.id)], limit=1
+        )
+
+    def _run_linker_transform_load(self, partner, qbo_customer):
+        """Run the QboCustomerLinker transform+load steps against a single QBO record."""
+        linker = self.env["qbo.customer.linker"]
+        ctx = _make_ctx(self.env)
+
+        # Simulate extracted data: one customer with _partner_id pre-filled
+        qbo_customer["_partner_id"] = partner.id
+        qbo_customer["_already_linked"] = False
+
+        extracted = {"extract_customers_for_linking": [qbo_customer]}
+        transformed_list = linker.transform_customers_for_linking(ctx, extracted)
+        transformed = {"transform_customers_for_linking": transformed_list}
+        linker.load_customer_links(ctx, transformed)
+
+    def test_ac1_linker_backfills_empty_address(self):
+        """AC1: linker writes all six address fields when partner has none."""
+        partner = self.env["res.partner"].create({"name": "ACME Corp", "is_company": True})
+        self.assertFalse(partner.street)
+        self.assertFalse(partner.country_id)
+
+        customer = _stub_qbo_customer(name="ACME Corp")
+        self._run_linker_transform_load(partner, customer)
+
+        partner.invalidate_recordset()
+        self.assertEqual(partner.street, "1 Main St")
+        self.assertEqual(partner.city, "Austin")
+        self.assertEqual(partner.zip, "78701")
+        self.assertEqual(partner.country_id.code, "US",
+                         "Country code must be US (not UM) when QBO supplies 'USA'")
+        self.assertEqual(partner.state_id.code, "TX")
+        self.assertEqual(partner.qbo_customer_id, 1)
+
+    def test_ac2_linker_does_not_clobber_existing_address(self):
+        """AC2: linker must not overwrite fields that are already set."""
+        partner = self.env["res.partner"].create({
+            "name": "Existing Corp",
+            "is_company": True,
+            "street": "Existing St",
+            "city": "Existing City",
+            "country_id": self.us_country.id,
+        })
+
+        customer = _stub_qbo_customer(
+            name="Existing Corp",
+            line1="Different St",
+            city="Different City",
+            country="CAN",  # different country
+        )
+        self._run_linker_transform_load(partner, customer)
+
+        partner.invalidate_recordset()
+        self.assertEqual(partner.street, "Existing St",
+                         "street must not be overwritten")
+        self.assertEqual(partner.city, "Existing City",
+                         "city must not be overwritten")
+        self.assertEqual(partner.country_id.id, self.us_country.id,
+                         "country_id must not be overwritten")
+        self.assertEqual(partner.qbo_customer_id, 1,
+                         "qbo_customer_id must still be linked")
+
+    def test_ac5_rerun_is_noop_on_address(self):
+        """AC5: re-running linker on a fully-addressed partner writes no address keys."""
+        partner = self.env["res.partner"].create({
+            "name": "Full Addr Corp",
+            "is_company": True,
+            "street": "123 Real Rd",
+            "city": "Houston",
+            "zip": "77001",
+            "country_id": self.us_country.id,
+            "state_id": self.tx_state.id,
+        })
+
+        customer = _stub_qbo_customer(name="Full Addr Corp")
+        self._run_linker_transform_load(partner, customer)
+        partner.invalidate_recordset()
+
+        # Address must be unchanged
+        self.assertEqual(partner.street, "123 Real Rd")
+        self.assertEqual(partner.city, "Houston")
+        self.assertEqual(partner.zip, "77001")
+        self.assertEqual(partner.state_id.id, self.tx_state.id)
+
+        # Second run (idempotent)
+        self._run_linker_transform_load(partner, customer)
+        partner.invalidate_recordset()
+        self.assertEqual(partner.street, "123 Real Rd",
+                         "Street must not change on second run")
+
+
+@tagged("post_install", "-at_install")
+class TestQboCountryAliasResolution(TransactionCase):
+    """AC3: create path resolves 'USA' → country_id.code == 'US'."""
+
+    def test_ac3_usa_resolves_to_us_not_um(self):
+        """AC3: _get_country_id('USA') returns the US country, not UM."""
+        importer = self.env["qbo.customer.importer"]
+        ctx = _make_ctx(self.env)
+        us_country = self.env.ref("base.us")
+
+        country_id = importer._get_country_id(ctx, "USA")
+        self.assertEqual(country_id, us_country.id,
+                         "USA must resolve to United States (code=US), not Minor Outlying Islands (UM)")
+
+    def test_can_resolves_to_ca(self):
+        """CAN must resolve to Canada (CA)."""
+        importer = self.env["qbo.customer.importer"]
+        ctx = _make_ctx(self.env)
+        ca_country = self.env.ref("base.ca")
+
+        country_id = importer._get_country_id(ctx, "CAN")
+        self.assertEqual(country_id, ca_country.id)
+
+    def test_iso2_passthrough(self):
+        """Two-letter ISO codes must pass through unchanged."""
+        importer = self.env["qbo.customer.importer"]
+        ctx = _make_ctx(self.env)
+        us_country = self.env.ref("base.us")
+
+        country_id = importer._get_country_id(ctx, "US")
+        self.assertEqual(country_id, us_country.id)
+
+    def test_vendor_importer_also_resolves_usa(self):
+        """QboVendorImporter._get_country_id must also resolve 'USA' correctly."""
+        importer = self.env["qbo.vendor.importer"]
+        ctx = _make_ctx(self.env)
+        us_country = self.env.ref("base.us")
+
+        country_id = importer._get_country_id(ctx, "USA")
+        self.assertEqual(country_id, us_country.id)
+
+
+@tagged("post_install", "-at_install")
+class TestQboVendorLinkerAddressBackfill(TransactionCase):
+    """AC4: vendor linker backfills address on empty partner."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.us_country = cls.env.ref("base.us")
+
+    def _run_vendor_linker(self, partner, qbo_vendor):
+        linker = self.env["qbo.vendor.linker"]
+        ctx = _make_ctx(self.env)
+
+        # Build the update dict the same way the transform would
+        bill_addr = qbo_vendor.get("BillAddr", {}) or {}
+        update = {
+            "partner_id": partner.id,
+            "qbo_vendor_id": int(qbo_vendor["Id"]),
+            "name": qbo_vendor.get("DisplayName", ""),
+            "addr_street": bill_addr.get("Line1"),
+            "addr_street2": bill_addr.get("Line2"),
+            "addr_city": bill_addr.get("City"),
+            "addr_zip": bill_addr.get("PostalCode"),
+            "addr_country_code": bill_addr.get("Country"),
+            "addr_state_code": bill_addr.get("CountrySubDivisionCode"),
+        }
+        transformed = {"transform_vendors_for_linking": [update]}
+        linker.load_vendor_links(ctx, transformed)
+
+    def test_ac4_vendor_linker_backfills_empty_address(self):
+        """AC4: vendor linker writes address fields to a partner with none."""
+        partner = self.env["res.partner"].create(
+            {"name": "Test Vendor LLC", "is_company": True}
+        )
+        self.assertFalse(partner.street)
+
+        vendor = _stub_qbo_vendor(name="Test Vendor LLC")
+        self._run_vendor_linker(partner, vendor)
+
+        partner.invalidate_recordset()
+        self.assertEqual(partner.street, "99 Supplier Ave")
+        self.assertEqual(partner.city, "Dallas")
+        self.assertEqual(partner.zip, "75201")
+        self.assertEqual(partner.country_id.code, "US")
+        self.assertEqual(partner.qbo_vendor_id, 10)

--- a/xtuple_to_odoo/models/pipelines/res_partner_etl.py
+++ b/xtuple_to_odoo/models/pipelines/res_partner_etl.py
@@ -361,12 +361,22 @@ class XtuplePartnerCustomerImporter(models.AbstractModel):
         # Transform customers that need xTuple fields updated
         update_vals = []
         for customer in customers_to_update:
+            address_info = self._extract_address_info(
+                customer, countries_dict, states_dict
+            )
             update_vals.append(
                 {
                     "name": customer.get("cust_name", ""),
                     "xtuple_cust_id": customer.get("cust_id"),
                     "xtuple_crmacct_id": customer.get("crmacct_id"),
                     "xtuple_partner_type": "customer",
+                    # Address info for backfill (per-field guard applied in load)
+                    "_addr_street": address_info["street"],
+                    "_addr_street2": address_info["street2"],
+                    "_addr_city": address_info["city"],
+                    "_addr_zip": address_info["zip"],
+                    "_addr_state_id": address_info["state"].id if address_info["state"] else False,
+                    "_addr_country_id": address_info["country"].id if address_info["country"] else False,
                 }
             )
 
@@ -393,10 +403,34 @@ class XtuplePartnerCustomerImporter(models.AbstractModel):
             updated = 0
             for vals in update_vals:
                 name = vals.pop("name")
+                # Extract address backfill values (prefixed with _addr_)
+                addr_backfill = {
+                    k[len("_addr_"):]: v
+                    for k, v in list(vals.items())
+                    if k.startswith("_addr_")
+                }
+                for k in list(vals.keys()):
+                    if k.startswith("_addr_"):
+                        del vals[k]
+
                 partner = ctx.env["res.partner"].search(
                     [("name", "=ilike", name)], limit=1
                 )
                 if partner:
+                    # Apply per-field address backfill (only fill empty fields)
+                    if not partner.street and addr_backfill.get("street"):
+                        vals["street"] = addr_backfill["street"]
+                    if not partner.street2 and addr_backfill.get("street2"):
+                        vals["street2"] = addr_backfill["street2"]
+                    if not partner.city and addr_backfill.get("city"):
+                        vals["city"] = addr_backfill["city"]
+                    if not partner.zip and addr_backfill.get("zip"):
+                        vals["zip"] = addr_backfill["zip"]
+                    if not partner.state_id and addr_backfill.get("state_id"):
+                        vals["state_id"] = addr_backfill["state_id"]
+                    if not partner.country_id and addr_backfill.get("country_id"):
+                        vals["country_id"] = addr_backfill["country_id"]
+
                     partner.write(vals)
                     updated += 1
             _logger.info(
@@ -557,12 +591,22 @@ class XtuplePartnerVendorImporter(models.AbstractModel):
         # Transform vendors that need xTuple fields updated (matched by name)
         update_vals = []
         for vendor in vendors_to_update:
+            address_info = self._extract_address_info(
+                vendor, countries_dict, states_dict
+            )
             update_vals.append(
                 {
                     "name": vendor.get("vend_name", ""),
                     "xtuple_vend_id": int(vendor.get("vend_id")),
                     "xtuple_crmacct_id": vendor.get("vend_crmacct_id"),
                     "xtuple_partner_type": "vendor",
+                    # Address info for backfill (per-field guard applied in load)
+                    "_addr_street": address_info["street"],
+                    "_addr_street2": address_info["street2"],
+                    "_addr_city": address_info["city"],
+                    "_addr_zip": address_info["zip"],
+                    "_addr_state_id": address_info["state"].id if address_info["state"] else False,
+                    "_addr_country_id": address_info["country"].id if address_info["country"] else False,
                 }
             )
 
@@ -604,10 +648,34 @@ class XtuplePartnerVendorImporter(models.AbstractModel):
             updated = 0
             for vals in update_vals:
                 name = vals.pop("name")
+                # Extract address backfill values (prefixed with _addr_)
+                addr_backfill = {
+                    k[len("_addr_"):]: v
+                    for k, v in list(vals.items())
+                    if k.startswith("_addr_")
+                }
+                for k in list(vals.keys()):
+                    if k.startswith("_addr_"):
+                        del vals[k]
+
                 partner = ctx.env["res.partner"].search(
                     [("name", "=ilike", name)], limit=1
                 )
                 if partner:
+                    # Apply per-field address backfill (only fill empty fields)
+                    if not partner.street and addr_backfill.get("street"):
+                        vals["street"] = addr_backfill["street"]
+                    if not partner.street2 and addr_backfill.get("street2"):
+                        vals["street2"] = addr_backfill["street2"]
+                    if not partner.city and addr_backfill.get("city"):
+                        vals["city"] = addr_backfill["city"]
+                    if not partner.zip and addr_backfill.get("zip"):
+                        vals["zip"] = addr_backfill["zip"]
+                    if not partner.state_id and addr_backfill.get("state_id"):
+                        vals["state_id"] = addr_backfill["state_id"]
+                    if not partner.country_id and addr_backfill.get("country_id"):
+                        vals["country_id"] = addr_backfill["country_id"]
+
                     partner.write(vals)
                     updated += 1
             _logger.info(

--- a/xtuple_to_odoo/tests/__init__.py
+++ b/xtuple_to_odoo/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_product_import
 from . import test_tools
 from . import test_xtuple_database
 from . import test_bom_import
+from . import test_partner_etl_addresses

--- a/xtuple_to_odoo/tests/test_partner_etl_addresses.py
+++ b/xtuple_to_odoo/tests/test_partner_etl_addresses.py
@@ -1,0 +1,251 @@
+"""Tests for xTuple partner ETL address backfill on the update path.
+
+Acceptance criteria:
+5. xTuple customer update-path backfills address fields when partner has none.
+6. xTuple customer update-path does NOT overwrite address fields already present.
+7. xTuple vendor linker (update path) backfills address on empty partner.
+8. Re-running the pipeline on an already-complete partner is a no-op on address fields.
+"""
+
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.etl_framework import ETLContext
+
+
+def _make_ctx(env):
+    """Build a minimal ETLContext backed by the Odoo test env."""
+    return ETLContext(cr=None, env=env)
+
+
+def _make_xtuple_customer(cust_id=1, name="Beta Ltd", **addr_kwargs):
+    """Build a minimal xTuple custinfo dict with address fields."""
+    defaults = {
+        "cust_id": cust_id,
+        "cust_number": f"CUST-{cust_id:04d}",
+        "cust_name": name,
+        "cust_active": True,
+        "cust_cntct_id": None,
+        "crmacct_id": None,
+        "cntct_first_name": None,
+        "cntct_last_name": None,
+        "cntct_honorific": None,
+        "cntct_initials": None,
+        "cntct_phone": None,
+        "cntct_phone2": None,
+        "cntct_fax": None,
+        "cntct_email": None,
+        "cntct_webaddr": None,
+        "cntct_notes": None,
+        "cntct_active": True,
+        "addr_line1": "42 xTuple Blvd",
+        "addr_line2": None,
+        "addr_line3": None,
+        "addr_city": "Boston",
+        "addr_state": "MA",
+        "addr_postalcode": "02101",
+        "addr_country": "US",
+        "addr_notes": None,
+        "crmacct_parent_id": None,
+    }
+    defaults.update(addr_kwargs)
+    return defaults
+
+
+def _make_xtuple_vendor(vend_id=2, name="Gamma Supplies", **addr_kwargs):
+    """Build a minimal xTuple vendinfo dict with address fields."""
+    defaults = {
+        "vend_id": vend_id,
+        "vend_number": f"VEND-{vend_id:04d}",
+        "vend_name": name,
+        "vend_active": True,
+        "vend_cntct_id": None,
+        "crmacct_id": None,
+        "vend_crmacct_id": None,
+        "cntct_first_name": None,
+        "cntct_last_name": None,
+        "cntct_honorific": None,
+        "cntct_initials": None,
+        "cntct_phone": None,
+        "cntct_phone2": None,
+        "cntct_fax": None,
+        "cntct_email": None,
+        "cntct_webaddr": None,
+        "cntct_notes": None,
+        "cntct_active": True,
+        "addr_line1": "7 Vendor Lane",
+        "addr_line2": None,
+        "addr_line3": None,
+        "addr_city": "Chicago",
+        "addr_state": "IL",
+        "addr_postalcode": "60601",
+        "addr_country": "US",
+        "addr_notes": None,
+        "crmacct_parent_id": None,
+    }
+    defaults.update(addr_kwargs)
+    return defaults
+
+
+@tagged("post_install", "-at_install")
+class TestXtupleCustomerUpdatePathAddressBackfill(TransactionCase):
+    """AC5, AC6, AC8: xTuple customer update-path address backfill."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.us_country = cls.env.ref("base.us")
+        cls.ma_state = cls.env["res.country.state"].search(
+            [("code", "=", "MA"), ("country_id", "=", cls.us_country.id)], limit=1
+        )
+
+    def _run_customer_update(self, partner, xtuple_row):
+        """Drive the transform+load update path for a single customer row."""
+        importer = self.env["xtuple.partner.customer.importer"]
+        ctx = _make_ctx(self.env)
+
+        # The transform path: inject a single row into customers_to_update
+        extracted = {
+            "extract_new_customers": [],
+            "extract_customers_to_update": [xtuple_row],
+        }
+        transformed_data = importer.transform_customers(ctx, extracted)
+        transformed = {"transform_customers": transformed_data}
+        importer.load_customers(ctx, transformed)
+
+    def test_ac5_update_path_backfills_empty_address(self):
+        """AC5: update path fills all address fields when partner has none."""
+        partner = self.env["res.partner"].create(
+            {"name": "Beta Ltd", "is_company": True}
+        )
+        self.assertFalse(partner.street)
+
+        row = _make_xtuple_customer(name="Beta Ltd")
+        self._run_customer_update(partner, row)
+
+        partner.invalidate_recordset()
+        self.assertEqual(partner.street, "42 xTuple Blvd")
+        self.assertEqual(partner.city, "Boston")
+        self.assertEqual(partner.zip, "02101")
+        self.assertEqual(partner.country_id.id, self.us_country.id)
+        self.assertEqual(partner.state_id.id, self.ma_state.id)
+        self.assertEqual(partner.xtuple_cust_id, 1)
+
+    def test_ac6_update_path_does_not_clobber_existing_address(self):
+        """AC6: update path must not overwrite existing address fields."""
+        partner = self.env["res.partner"].create({
+            "name": "Delta Inc",
+            "is_company": True,
+            "street": "Existing Avenue",
+            "city": "Existing City",
+            "country_id": self.us_country.id,
+        })
+
+        row = _make_xtuple_customer(
+            name="Delta Inc",
+            addr_line1="Different Street",
+            addr_city="Different City",
+        )
+        self._run_customer_update(partner, row)
+
+        partner.invalidate_recordset()
+        self.assertEqual(partner.street, "Existing Avenue",
+                         "street must not be overwritten")
+        self.assertEqual(partner.city, "Existing City",
+                         "city must not be overwritten")
+        self.assertEqual(partner.country_id.id, self.us_country.id,
+                         "country_id must not be overwritten")
+        self.assertEqual(partner.xtuple_cust_id, 1,
+                         "xtuple_cust_id must still be set")
+
+    def test_ac8_rerun_is_noop_on_address(self):
+        """AC8: re-running the pipeline on a complete partner does not modify address."""
+        partner = self.env["res.partner"].create({
+            "name": "Epsilon LLC",
+            "is_company": True,
+            "street": "Fixed St",
+            "city": "Fixed City",
+            "zip": "11111",
+            "country_id": self.us_country.id,
+            "state_id": self.ma_state.id,
+        })
+
+        row = _make_xtuple_customer(name="Epsilon LLC")
+        self._run_customer_update(partner, row)
+        partner.invalidate_recordset()
+        write_date_after_first = partner.write_date
+
+        # Run again — address write_date should not advance further
+        self._run_customer_update(partner, row)
+        partner.invalidate_recordset()
+
+        self.assertEqual(partner.street, "Fixed St",
+                         "street must be unchanged on second run")
+        self.assertEqual(partner.city, "Fixed City",
+                         "city must be unchanged on second run")
+
+
+@tagged("post_install", "-at_install")
+class TestXtupleVendorUpdatePathAddressBackfill(TransactionCase):
+    """AC7: xTuple vendor update-path address backfill."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.us_country = cls.env.ref("base.us")
+        cls.il_state = cls.env["res.country.state"].search(
+            [("code", "=", "IL"), ("country_id", "=", cls.us_country.id)], limit=1
+        )
+
+    def _run_vendor_update(self, partner, xtuple_row):
+        """Drive the transform+load update path for a single vendor row."""
+        importer = self.env["xtuple.partner.vendor.importer"]
+        ctx = _make_ctx(self.env)
+
+        extracted = {
+            "extract_new_vendors": [],
+            "extract_vendors_to_update": [xtuple_row],
+        }
+        transformed_data = importer.transform_vendors(ctx, extracted)
+        transformed = {"transform_vendors": transformed_data}
+        importer.load_vendors(ctx, transformed)
+
+    def test_ac7_vendor_update_path_backfills_empty_address(self):
+        """AC7: vendor update path fills address fields when partner has none."""
+        partner = self.env["res.partner"].create(
+            {"name": "Gamma Supplies", "is_company": True}
+        )
+        self.assertFalse(partner.street)
+
+        row = _make_xtuple_vendor(name="Gamma Supplies")
+        self._run_vendor_update(partner, row)
+
+        partner.invalidate_recordset()
+        self.assertEqual(partner.street, "7 Vendor Lane")
+        self.assertEqual(partner.city, "Chicago")
+        self.assertEqual(partner.zip, "60601")
+        self.assertEqual(partner.country_id.id, self.us_country.id)
+        self.assertEqual(partner.state_id.id, self.il_state.id)
+        self.assertEqual(partner.xtuple_vend_id, 2)
+
+    def test_vendor_update_does_not_clobber_existing_address(self):
+        """Vendor update path must not overwrite existing address fields."""
+        partner = self.env["res.partner"].create({
+            "name": "Zeta Trading",
+            "is_company": True,
+            "street": "Old Vendor St",
+            "city": "Old City",
+            "country_id": self.us_country.id,
+        })
+
+        row = _make_xtuple_vendor(
+            name="Zeta Trading",
+            addr_line1="New Vendor St",
+            addr_city="New City",
+        )
+        self._run_vendor_update(partner, row)
+
+        partner.invalidate_recordset()
+        self.assertEqual(partner.street, "Old Vendor St",
+                         "street must not be overwritten")
+        self.assertEqual(partner.city, "Old City",
+                         "city must not be overwritten")

--- a/xtuple_to_odoo/tests/test_partner_etl_addresses.py
+++ b/xtuple_to_odoo/tests/test_partner_etl_addresses.py
@@ -86,7 +86,7 @@ def _make_xtuple_vendor(vend_id=2, name="Gamma Supplies", **addr_kwargs):
     return defaults
 
 
-@tagged("post_install", "-at_install")
+@tagged("post_install", "-at_install", "partner_address_etl")
 class TestXtupleCustomerUpdatePathAddressBackfill(TransactionCase):
     """AC5, AC6, AC8: xTuple customer update-path address backfill."""
 
@@ -184,7 +184,7 @@ class TestXtupleCustomerUpdatePathAddressBackfill(TransactionCase):
                          "city must be unchanged on second run")
 
 
-@tagged("post_install", "-at_install")
+@tagged("post_install", "-at_install", "partner_address_etl")
 class TestXtupleVendorUpdatePathAddressBackfill(TransactionCase):
     """AC7: xTuple vendor update-path address backfill."""
 


### PR DESCRIPTION
Upstream fix for the Vera Inkjet partner-address ETL bug (Odoo task #3200).

## Root cause
The linker paths (QboCustomerLinker, QboVendorLinker, xTuple update paths) never wrote address fields, so any partner that first appeared empty-addressed stayed empty. Separately, _get_country_id used name ilike country_code which collided "USA" → "United States Minor Outlying Islands" (code UM).

## Fix
- qbo_to_odoo: extend linker transform+load to carry address fields + per-field empty guard; harden _get_country_id with explicit alpha-3 alias map (15 common codes) + tightened =ilike name fallback (length > 3).
- xtuple_to_odoo: symmetric fix in update path via _addr_* prefixed keys stripped before write.
- Tests: 13 new under --test-tags=partner_address_etl, all passing.

Pipeline artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3200-fix-partner-address-etl