### PR TITLE
feat: port studio_cleanup to 19.0

### DIFF
--- a/studio_cleanup/README.md
+++ b/studio_cleanup/README.md
@@ -1,0 +1,131 @@
+# Studio Cleanup Helpers
+
+A lightweight Odoo module providing reusable helper functions for cleaning up Studio views that have been migrated to module code.
+
+## Purpose
+
+When migrating Studio customizations to version-controlled module code, the original Studio views need to be deleted to avoid conflicts. This module provides a safe, reusable way to do this cleanup.
+
+## Features
+
+- ✅ **Lightweight**: No UI, no dependencies beyond `base`
+- ✅ **Production-ready**: Safe to install in production
+- ✅ **Reusable**: Use in any module that has migrated Studio views
+- ✅ **Safe**: Deletes only specified views by exact external ID
+- ✅ **Detailed logging**: Clear logs of what was deleted
+
+## Installation
+
+1. Add this module to your addons path
+2. Install it: `Apps > Studio Cleanup Helpers > Install`
+3. Add it as a dependency in modules that need cleanup
+
+## Usage
+
+### 1. Add Dependency
+
+In your module's `__manifest__.py`:
+
+```python
+{
+    'name': 'My Module',
+    'depends': ['base', 'studio_cleanup'],  # Add studio_cleanup
+    # ...
+}
+```
+
+### 2. Create hooks.py
+
+Create or update `hooks.py` in your module:
+
+```python
+# -*- coding: utf-8 -*-
+
+from odoo.addons.studio_cleanup.tools import cleanup_studio_views_by_xmlid
+
+
+def post_init_hook(env):
+    """Clean up Studio views after module installation/upgrade."""
+    studio_view_ids_to_delete = [
+        'studio_customization.odoo_studio_stock_production_lot_tree_customization',
+        'studio_customization.odoo_studio_stock_picking_form_customization',
+    ]
+    
+    cleanup_studio_views_by_xmlid(env, studio_view_ids_to_delete, 'my_module')
+```
+
+### 3. Update __init__.py
+
+```python
+from . import models
+from . import hooks  # Add this
+```
+
+### 4. Update __manifest__.py
+
+```python
+{
+    'name': 'My Module',
+    'depends': ['base', 'studio_cleanup'],
+    'post_init_hook': 'post_init_hook',  # Add this
+    # ...
+}
+```
+
+## How It Works
+
+1. When you upgrade a module with a `post_init_hook`
+2. The hook calls `cleanup_studio_views_by_xmlid()`
+3. The function tries to find each Studio view by its external ID
+4. If found, the view is deleted
+5. Detailed logs are written to `odoo.log`
+
+## Example Log Output
+
+```
+INFO: [durpro_stock] ✓ Deleted Studio view: Odoo Studio: stock.lot.tree (ID: 10449, XML ID: studio_customization.odoo_studio_xxx)
+INFO: [durpro_stock] Studio views cleanup completed: 3 deleted, 0 skipped, 0 failed
+```
+
+## Development vs Production
+
+### Development
+- Use `studio_to_module` to convert Studio views to XML
+- `studio_to_module` automatically generates `hooks.py` using this module
+
+### Production
+- Only install `studio_cleanup` (not `studio_to_module`)
+- Deploy your modules with `hooks.py` already generated
+- Hooks run automatically on module upgrade
+
+## API Reference
+
+### cleanup_studio_views_by_xmlid(env, studio_view_xmlids, module_name)
+
+Delete specific Studio views by their external IDs.
+
+**Parameters:**
+- `env` (Environment): Odoo environment
+- `studio_view_xmlids` (list): List of external IDs to delete (e.g., `['studio_customization.odoo_studio_xxx']`)
+- `module_name` (str): Name of the calling module (for logging)
+
+**Returns:**
+- `int`: Number of views successfully deleted
+
+**Example:**
+```python
+deleted = cleanup_studio_views_by_xmlid(
+    env, 
+    ['studio_customization.odoo_studio_stock_lot_tree_customization'],
+    'durpro_stock'
+)
+# deleted = 1
+```
+
+## License
+
+LGPL-3
+
+## Author
+
+Durpro

--- a/studio_cleanup/__init__.py
+++ b/studio_cleanup/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import tools

--- a/studio_cleanup/__manifest__.py
+++ b/studio_cleanup/__manifest__.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Studio Cleanup Helpers',
+    'version': '19.0.1.0.0',
+    'category': 'Technical',
+    'summary': 'Helper functions for cleaning up migrated Studio views',
+    'description': """
+Studio Cleanup Helpers
+======================
+
+This module provides reusable helper functions for cleaning up Studio views
+that have been migrated to module code.
+
+Key Features:
+-------------
+* Lightweight module with no UI
+* Reusable cleanup functions
+* Safe deletion by external ID
+* Detailed logging
+* Production-ready
+
+Usage:
+------
+Add this module as a dependency in modules that have migrated Studio views::
+
+    'depends': ['base', 'studio_cleanup'],
+
+Then in your module's hooks.py::
+
+    from odoo.addons.studio_cleanup.tools import cleanup_studio_views_by_xmlid
+    
+    def post_init_hook(env):
+        studio_view_ids = [
+            'studio_customization.odoo_studio_xxx',
+        ]
+        cleanup_studio_views_by_xmlid(env, studio_view_ids, 'my_module')
+
+This module is designed to be installed in production environments.
+    """,
+    'author': 'Durpro',
+    'website': 'https://www.durpro.com',
+    'depends': ['base'],
+    'data': [],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+    'license': 'LGPL-3',
+}

--- a/studio_cleanup/tools/__init__.py
+++ b/studio_cleanup/tools/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from .cleanup_helpers import cleanup_studio_views_by_xmlid
+
+__all__ = ['cleanup_studio_views_by_xmlid']

--- a/studio_cleanup/tools/cleanup_helpers.py
+++ b/studio_cleanup/tools/cleanup_helpers.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""
+Helper functions for cleaning up Studio views after migration.
+
+This module provides reusable functions that can be called from any module's hooks.py
+to clean up Studio views that have been migrated to module code.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def cleanup_studio_views_by_xmlid(env, studio_view_xmlids, module_name):
+    """Delete specific Studio views by their external IDs.
+    
+    This is a reusable function that can be called from any module's post_init_hook
+    to clean up Studio views that have been migrated to module code.
+    
+    :param env: Odoo environment
+    :param list studio_view_xmlids: List of Studio view external IDs to delete
+                                     Format: 'module.xml_id' (e.g., 'studio_customization.odoo_studio_xxx')
+    :param str module_name: Name of the calling module (for logging)
+    :return: Number of views deleted
+    :rtype: int
+    
+    Example usage in a module's hooks.py:
+        from odoo.addons.studio_cleanup.tools import cleanup_studio_views_by_xmlid
+        
+        def post_init_hook(env):
+            studio_view_ids = [
+                'studio_customization.odoo_studio_stock_lot_tree_customization',
+                'studio_customization.odoo_studio_stock_picking_form_customization',
+            ]
+            cleanup_studio_views_by_xmlid(env, studio_view_ids, 'my_module')
+    """
+    if not studio_view_xmlids:
+        _logger.info("[%s] No Studio views to clean up", module_name)
+        return 0
+    
+    deleted_count = 0
+    skipped_count = 0
+    failed_count = 0
+    
+    for xml_id in studio_view_xmlids:
+        try:
+            # Try to get the view by external ID
+            view = env.ref(xml_id, raise_if_not_found=False)
+            
+            if view:
+                view_name = view.name
+                view_id = view.id
+                view.sudo().unlink()
+                deleted_count += 1
+                _logger.info("[%s] ✓ Deleted Studio view: %s (ID: %s, XML ID: %s)", 
+                           module_name, view_name, view_id, xml_id)
+            else:
+                skipped_count += 1
+                _logger.debug("[%s] ○ Studio view not found (already deleted?): %s", 
+                            module_name, xml_id)
+                
+        except Exception as e:
+            failed_count += 1
+            _logger.warning("[%s] ✗ Failed to delete Studio view %s: %s", 
+                          module_name, xml_id, e)
+    
+    # Summary log
+    if deleted_count > 0:
+        _logger.info("[%s] Studio views cleanup completed: %d deleted, %d skipped, %d failed", 
+                    module_name, deleted_count, skipped_count, failed_count)
+    elif skipped_count > 0:
+        _logger.info("[%s] No Studio views deleted (all %d already cleaned up)", 
+                    module_name, skipped_count)
+    else:
+        _logger.info("[%s] No Studio views to clean up", module_name)
+    
+    return deleted_count


### PR DESCRIPTION
## Summary

Ports the `studio_cleanup` helper module from `18.0` to `19.0`.

`studio_cleanup` is a small utility (5 files, no UI, no data) that
exposes one function:

\`\`\`python
from odoo.addons.studio_cleanup.tools import cleanup_studio_views_by_xmlid

def post_init_hook(env):
    cleanup_studio_views_by_xmlid(env, ['studio_customization.odoo_studio_xxx'], 'my_module')
\`\`\`

It's a dependency of post-init cleanup hooks in modules that have
migrated their Studio customizations to module code.

The only Odoo API touchpoint is \`env.ref(xml_id, raise_if_not_found=False)\`
which is unchanged in 19.0. No code modifications needed — just a
manifest version bump (\`18.0.1.0.0 → 19.0.1.0.0\`).

### Why now

The durpro/DurPro CI build job has been failing since the 19.0
branch was created:

\`\`\`
ERROR: broken addons symlink: ./addons/studio_cleanup -> ../.repos/bemade-tools/studio_cleanup
ERROR: 1 broken symlink(s) under ./addons/ — refusing to build
\`\`\`

The parent repo has a symlink \`addons/studio_cleanup\` pointing at
this submodule, but the \`19.0\` branch never received the port,
breaking the symlink and gating the entire CI build (the \`test\`
job was skipped on every run for 2+ days). This PR unblocks it.

## Test plan

- [x] Fresh DB install on Odoo 19.0: \`Modules loaded.\` with no errors
- [x] Manifest version is now \`19.0.1.0.0\`
- [x] Symlink \`addons/studio_cleanup\` from parent repo now resolves

Once merged, I'll bump the bemade-tools submodule pointer in
durpro/DurPro and trigger a fresh CI pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)