### PR TITLE
[sap_b1_to_odoo] Make SAP item code findable via Products list-view search box

### DIFF
--- a/sap_b1_to_odoo/tests/pipelines/test_product_search.py
+++ b/sap_b1_to_odoo/tests/pipelines/test_product_search.py
@@ -37,8 +37,11 @@ Acceptance criteria:
 import logging
 from unittest.mock import MagicMock, patch
 
+from lxml import etree
+
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
+from odoo.tools.safe_eval import safe_eval
 
 
 # ---------------------------------------------------------------------------
@@ -158,6 +161,107 @@ class TestSapProductSearch(TransactionCase):
             result_ids,
             "product.template.name_search must return the template when searching "
             "by its sap_item_code.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Default-facet search (type-and-Enter in the list-view search box)
+# ---------------------------------------------------------------------------
+
+@tagged("-at_install", "post_install", "sap_default_facet_search")
+class TestSapDefaultFacetSearch(TransactionCase):
+    """Guards that the search-view default facet (plain type-and-Enter) includes
+    sap_item_code, so typing a SAP item code in Sales/Inventory → Products and
+    pressing Enter returns the product without picking an explicit facet.
+
+    Unlike TestSapProductSearch (which covers name_search, powering many2one
+    dropdowns), this exercises the list-view search box, which runs the search
+    view's default `name` field filter_domain — not name_search.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # name/default_code/barcode deliberately do NOT contain the SAP code, so a
+        # match on the SAP code can only come from the sap_item_code term.
+        cls.product = cls.env["product.product"].create({
+            "name": "Widget Alpha",
+            "default_code": "WA-001",
+            "barcode": "9990001112223",
+            "sap_item_code": "GP42155X00P",
+        })
+
+    def _default_filter_domain(self, model, view_xmlid):
+        """Pull the rendered default-facet filter_domain string from a search view."""
+        view = self.env.ref(view_xmlid)
+        arch = self.env[model].get_view(view.id, "search")["arch"]
+        node = etree.fromstring(arch.encode()).xpath("//search/field[@name='name']")[0]
+        return node.get("filter_domain")
+
+    def test_template_search_view_default_facet_finds_sap_code(self):
+        """Sales (product.template) default facet matches by sap_item_code."""
+        filter_domain = self._default_filter_domain(
+            "product.template", "product.product_template_search_view"
+        )
+        self.assertIn(
+            "sap_item_code",
+            filter_domain,
+            "product.template default search facet must include sap_item_code "
+            "(filter_domain override not applied).",
+        )
+        domain = safe_eval(filter_domain, {"self": "GP42155X00P"})
+        results = self.env["product.template"].search(domain)
+        self.assertIn(
+            self.product.product_tmpl_id,
+            results,
+            "Default-facet search by SAP item code must return the template.",
+        )
+
+    def test_stock_search_view_default_facet_finds_sap_code(self):
+        """Inventory (product.product) default facet matches by sap_item_code."""
+        filter_domain = self._default_filter_domain(
+            "product.product", "stock.stock_product_search_form_view"
+        )
+        self.assertIn(
+            "sap_item_code",
+            filter_domain,
+            "product.product (stock) default search facet must include sap_item_code "
+            "(filter_domain override not applied).",
+        )
+        domain = safe_eval(filter_domain, {"self": "GP42155X00P"})
+        results = self.env["product.product"].search(domain)
+        self.assertIn(
+            self.product,
+            results,
+            "Default-facet search by SAP item code must return the product.",
+        )
+
+    def test_default_facet_still_matches_name_code_barcode(self):
+        """The Sales default facet still matches by default_code, name, barcode
+        (regression guard — existing terms preserved, not clobbered)."""
+        filter_domain = self._default_filter_domain(
+            "product.template", "product.product_template_search_view"
+        )
+        for probe in ("WA-001", "Widget Alpha", "9990001112223"):
+            domain = safe_eval(filter_domain, {"self": probe})
+            results = self.env["product.template"].search(domain)
+            self.assertIn(
+                self.product.product_tmpl_id,
+                results,
+                "Default-facet search by %r must still return the template." % probe,
+            )
+
+    def test_default_facet_does_not_match_unrelated(self):
+        """An unrelated probe returns nothing (the domain is not a tautology)."""
+        filter_domain = self._default_filter_domain(
+            "product.template", "product.product_template_search_view"
+        )
+        domain = safe_eval(filter_domain, {"self": "ZZZ-NOPE-XYZ"})
+        results = self.env["product.template"].search(domain)
+        self.assertNotIn(
+            self.product.product_tmpl_id,
+            results,
+            "Unrelated probe must not match the product.",
         )
 
 

--- a/sap_b1_to_odoo/views/sap_field_views.xml
+++ b/sap_b1_to_odoo/views/sap_field_views.xml
@@ -74,6 +74,9 @@
             <field name="product_tag_ids" position="before">
                 <field name="sap_item_code"/>
             </field>
+            <field name="name" position="attributes">
+                <attribute name="filter_domain">['|', '|', '|', '|', ('default_code', 'ilike', self), ('product_variant_ids.default_code', 'ilike', self), ('name', 'ilike', self), ('barcode', 'ilike', self), ('sap_item_code', 'ilike', self)]</attribute>
+            </field>
         </field>
     </record>
 
@@ -84,6 +87,9 @@
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <field name="sap_item_code"/>
+            </field>
+            <field name="name" position="attributes">
+                <attribute name="filter_domain">['|', '|', '|', ('default_code', 'ilike', self), ('name', 'ilike', self), ('barcode', 'ilike', self), ('sap_item_code', 'ilike', self)]</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
## What
Extends the **default search facet** (plain type-and-Enter) of the Sales and Inventory **Products** list views to also match `sap_item_code`.

## Why
RWI task #3734 was kicked back after live testing: typing a SAP item code (e.g. `GP42155X00P`) in **Sales → Products** and pressing Enter did not find the product. The prior fixes covered:
- `name_search` overrides → many2one **dropdowns** (works), and
- a separate **"SAP Item Code"** search facet (works only if the user explicitly selects it).

But the list-view search box's *default* facet is the search view's `name` field `filter_domain`, which only covered name/default_code/barcode. Plain type-and-Enter never matched the SAP code.

## Change
Override the default `name`-facet `filter_domain` to OR in `('sap_item_code', 'ilike', self)` on both core search views, preserving the existing terms and the explicit facets:
- `product.product_template_search_view` (Sales → Products)
- `stock.stock_product_search_form_view` → `product.product_search_form_view` (Inventory → Products)

Additive and gated on `sap_item_code` being set, so non-SAP deployments are unaffected. `sap_item_code` is a btree-indexed Char, so the `ilike` term is index-assisted.

## Tests
New `TestSapDefaultFacetSearch` (tag `sap_default_facet_search`): pulls each view's rendered default `filter_domain`, asserts a SAP-code search returns a product whose name/default_code/barcode deliberately do **not** contain the code (so the match can only come from `sap_item_code`), that name/code/barcode search still works, and that an unrelated probe matches nothing. Fail-before / pass-after. 4/4 pass.

> Note: the module's full suite has 10 unrelated pre-existing failures (`TestAccountMoveJDT1YearendRedirect` → missing `_detect_closing`) that exist on `19.0` independent of this change; this PR touches only the two search files.

## How to test manually
1. Upgrade `sap_b1_to_odoo`.
2. **Sales → Products → Products**: type a SAP item code in the search box, press **Enter** (do not pick a facet) → the product appears.
3. **Inventory → Products**: same.
4. Confirm searching by internal reference, name, and barcode still works.