### PR TITLE
[3810] xtuple_to_odoo: generate component PICK automatically on full import (supersedes #23)

### DIFF
--- a/xtuple_to_odoo/models/pipelines/mrp_production_etl.py
+++ b/xtuple_to_odoo/models/pipelines/mrp_production_etl.py
@@ -373,3 +373,158 @@ class XtupleMrpConsumptionImporter(models.AbstractModel):
             ctx.env["stock.move"].with_context(tracking_disable=True).create(move_vals)
         )
         _logger.info(f"Created {len(moves)} component stock moves")
+
+
+# =============================================================================
+# Component PICK generation (task 3810)
+# =============================================================================
+#
+# The MO importer (above) writes ``state`` directly and only ``.create()``s the
+# MO; the consumption importer ``.create()``s the component (raw) moves.  Neither
+# confirms the MO, so std Odoo never runs the manufacture/pbm procurement that
+# generates the upstream component PICK (the ``stock -> pre-production`` transfer
+# a 2-step ``pbm`` warehouse needs before the components can be picked).
+#
+# Per the full-import sequence in ``scripts/test_import.py`` the warehouse cycle
+# is configured (``manufacture_steps='pbm'``, ``pbm_loc_id``/``pbm_type_id`` and
+# the pbm pull rules) by ``verajet.configurator.action_run_pre_import`` *before*
+# ``xtuple.database.action_import_all`` runs.  So by the time MOs/raw moves are
+# materialised the warehouse is already ``pbm`` and each imported open/in-progress
+# MO already has its ``location_src_id`` at the pbm location and its raw moves
+# carrying the MO's ``production_group_id`` / ``reference_ids``
+# (``mrp/models/stock_move.py`` create override).  The *only* missing piece is
+# the confirmation that runs procurement.
+#
+# This pipeline closes that gap AUTOMATICALLY as the final step of a full import:
+# it calls the MO's native ``action_confirm()`` on each open/in-progress imported
+# MO.  ``action_confirm`` confirms the MO's *existing* raw moves and runs the pbm
+# pull rule via procurement (``_action_confirm(create_proc=True)``), generating
+# exactly the component PICK std Odoo would have created on a normal confirm —
+# correctly grouped onto ``mo.picking_ids`` because the procurement carries
+# ``production_group_id`` (``mrp/models/stock_move._prepare_procurement_values``).
+#
+# Why this does NOT double the imported raw moves:
+#   * ``_compute_move_raw_ids`` early-returns for any non-draft MO
+#     (``mrp/models/mrp_production.py``: ``if production.state != 'draft'``), so
+#     the BOM is never re-exploded for an imported confirmed/progress/to_close MO.
+#   * ``action_confirm`` operates on the MO's *existing* ``move_raw_ids`` — it
+#     confirms them, it does not create a second consumption set.
+#   * ``stock.move._action_confirm`` skips moves whose state is not ``draft``
+#     (``if move.state != 'draft': continue``), so re-running is idempotent at the
+#     move level too; and we additionally skip any MO that already has a pbm PICK.
+#
+# This supersedes the rejected approach (hand-building pick moves + a deliberate
+# "no-op at import, re-run after route config"): here PICK generation is native
+# and happens automatically within ``action_import_all``, no manual re-run.
+
+
+@ETL.pipeline(
+    target_model="mrp.production",
+    importer_name="xtuple.mrp.pick.generator",
+    depends_on=[
+        "xtuple.mrp.consumption.importer",
+    ],
+)
+class XtupleMrpPickGenerator(models.AbstractModel):
+    """Confirm imported open/in-progress MOs so their component PICK is
+    generated natively (task 3810).
+
+    Runs after the consumption importer (its component moves must exist first)
+    and is auto-included in ``action_import_all`` via the ``xtuple_to_odoo``
+    module filter.  Load-only: it has no xTuple payload to extract/transform —
+    its work is a DB query over already-imported MOs, which also makes it
+    idempotent and safe to re-run.
+    """
+
+    _name = "xtuple.mrp.pick.generator"
+    _description = "xTuple MO Component PICK Generator"
+
+    # xTuple-status -> Odoo-state mapping (see transform_productions) yields
+    # these "open / in-progress" states for MOs that should have a live PICK.
+    _OPEN_STATES = ("confirmed", "progress", "to_close")
+
+    @ETL.load()
+    def generate_component_pickings(self, ctx: ETLContext, transformed: Dict) -> None:
+        """Confirm every open/in-progress imported MO that still lacks its PICK.
+
+        Queries the DB directly (does not trust any transform payload) so the
+        step is re-runnable and order-independent.
+        """
+        productions = ctx.env["mrp.production"].search(
+            [
+                ("xtuple_wo_id", "!=", False),
+                ("state", "in", self._OPEN_STATES),
+            ]
+        )
+        confirmed = 0
+        skipped = 0
+        for production in productions:
+            if self._confirm_imported_mo(ctx, production):
+                confirmed += 1
+            else:
+                skipped += 1
+        _logger.info(
+            "PICK generation: confirmed %d MO(s), skipped %d already-PICKed/empty",
+            confirmed,
+            skipped,
+        )
+
+    def _confirm_imported_mo(self, ctx: ETLContext, production) -> bool:
+        """Confirm one imported MO so Odoo generates its component PICK natively.
+
+        Returns True if the MO was confirmed (PICK generated), False if it was
+        skipped (no pick step, already has a PICK, or has no raw moves).
+        """
+        warehouse = production.warehouse_id
+
+        # Skip if the warehouse has no pick step — std Odoo has no component PICK
+        # in a 1-step manufacture warehouse (components are consumed straight from
+        # stock).  This is the correct no-op if the cycle was not configured to
+        # ``pbm``.  With the test_import.py sequence (pre-import config) the
+        # warehouse IS ``pbm`` here, so this does not short-circuit the feature.
+        if (
+            warehouse.manufacture_steps not in ("pbm", "pbm_sam")
+            or not warehouse.pbm_type_id
+        ):
+            _logger.debug(
+                "MO %s: warehouse %s has no pick step — skipping PICK generation",
+                production.name,
+                warehouse.name,
+            )
+            return False
+
+        # Idempotency: skip if a pbm-type PICK already exists for this MO.
+        # Search stock.move directly (cache-independent within a transaction) for
+        # a pbm-type move pointing at this MO's production group with a picking.
+        existing_pick_move = ctx.env["stock.move"].search_count(
+            [
+                ("production_group_id", "=", production.production_group_id.id),
+                ("picking_type_id", "=", warehouse.pbm_type_id.id),
+                ("picking_id", "!=", False),
+            ]
+        )
+        if existing_pick_move:
+            _logger.debug(
+                "MO %s already has a %s PICK — skipping",
+                production.name,
+                warehouse.pbm_type_id.name,
+            )
+            return False
+
+        # Nothing to wrap if the MO has no imported component moves.
+        if not production.move_raw_ids.filtered(lambda m: m.xtuple_womatl_id):
+            _logger.debug("MO %s has no imported raw moves — skipping", production.name)
+            return False
+
+        # Native confirm: confirms the MO's EXISTING raw moves and runs the pbm
+        # pull rule via procurement, generating the component PICK.  Does NOT
+        # re-explode the BOM (the MO is non-draft, so _compute_move_raw_ids is a
+        # no-op) and does NOT touch the MO's state for non-draft MOs
+        # (action_confirm only flips draft -> confirmed).
+        production.action_confirm()
+        _logger.info(
+            "MO %s: confirmed -> generated component PICK on %s",
+            production.name,
+            warehouse.pbm_type_id.name,
+        )
+        return True

--- a/xtuple_to_odoo/tests/__init__.py
+++ b/xtuple_to_odoo/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_tools
 from . import test_xtuple_database
 from . import test_bom_import
 from . import test_partner_etl_addresses
+from . import test_mo_pick_import

--- a/xtuple_to_odoo/tests/test_mo_pick_import.py
+++ b/xtuple_to_odoo/tests/test_mo_pick_import.py
@@ -1,0 +1,311 @@
+"""Tests for automatic component-PICK generation on imported MOs (task 3810).
+
+Acceptance criteria (Marc, 2026-06-18):
+1. A FULL import yields open/in-progress MOs WITH their component PICK
+   AUTOMATICALLY — no manual re-run.  Realised by ``xtuple.mrp.pick.generator``
+   calling the MO's native ``action_confirm()``, which runs the pbm pull rule.
+2. The already-imported consumption (raw) moves are NOT regenerated or doubled.
+3. PICK generation uses Odoo's native confirm/procurement path (no hand-built
+   pick moves, no deliberate import-time no-op).
+4. Closed/done/cancel/draft MOs are unaffected.
+
+These tests reproduce the REAL full-import sequence of ``scripts/test_import.py``:
+the warehouse cycle is configured to ``pbm`` (pre-import config) BEFORE the MO
+and its raw moves are materialised.  So each imported open/in-progress MO already
+sits at the pbm source location and its raw moves carry the production group; the
+only missing piece — the confirmation that runs procurement — is supplied by the
+generator step.
+
+No live xTuple DB — pure Odoo records, mirroring ``test_partner_etl_addresses``.
+"""
+
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.etl_framework import ETLContext
+
+
+def _make_ctx(env):
+    """Build a minimal ETLContext backed by the Odoo test env."""
+    return ETLContext(cr=None, env=env)
+
+
+@tagged("post_install", "-at_install", "xtuple")
+class TestXtupleMrpPickGenerator(TransactionCase):
+    """Automatic component-PICK generation for open/in-progress imported MOs."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.generator = cls.env["xtuple.mrp.pick.generator"]
+        cls.company = cls.env.company
+
+        cls.wh = cls.env["stock.warehouse"].search(
+            [("company_id", "=", cls.company.id)], limit=1
+        )
+        # Configure the warehouse cycle to pbm (2-step manufacturing) BEFORE
+        # any MO/raw move is created — exactly as verajet.configurator's
+        # pre-import config does ahead of the xTuple import in test_import.py.
+        # This auto-provisions pbm_loc_id / pbm_type_id / pbm_route_id + rules.
+        cls.wh.write({"manufacture_steps": "pbm"})
+        assert cls.wh.pbm_type_id, "pbm warehouse must provision pbm_type_id"
+        assert cls.wh.pbm_loc_id, "pbm warehouse must provision pbm_loc_id"
+
+        cls.prod_loc = cls.env["stock.location"].search(
+            [("usage", "=", "production"), ("company_id", "=", cls.company.id)],
+            limit=1,
+        )
+
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+
+        # Finished product + two storable components, all manufacturable.
+        cls.finished = cls.env["product.product"].create(
+            {"name": "PICK-Finished", "is_storable": True}
+        )
+        cls.comp_a = cls.env["product.product"].create(
+            {"name": "PICK-Comp-A", "is_storable": True}
+        )
+        cls.comp_b = cls.env["product.product"].create(
+            {"name": "PICK-Comp-B", "is_storable": True}
+        )
+
+        cls.bom = cls.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": cls.finished.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "normal",
+                "bom_line_ids": [
+                    (0, 0, {"product_id": cls.comp_a.id, "product_qty": 2.0}),
+                    (0, 0, {"product_id": cls.comp_b.id, "product_qty": 3.0}),
+                ],
+            }
+        )
+
+    # ---- fixture helpers -------------------------------------------------
+
+    _next_wo = 1000
+
+    def _make_imported_mo(self, state="progress"):
+        """Create an imported MO mirroring the importer: ``state`` written
+        directly, no explicit ``picking_type_id`` (let the computes resolve it
+        against the live pbm warehouse — as the real import does post-config)."""
+        type(self)._next_wo += 1
+        wo_id = type(self)._next_wo
+        mo = (
+            self.env["mrp.production"]
+            .with_context(tracking_disable=True)
+            .create(
+                {
+                    "name": f"WO{wo_id}",
+                    "product_id": self.finished.id,
+                    "product_uom_id": self.uom_unit.id,
+                    "product_qty": 1.0,
+                    "bom_id": self.bom.id,
+                    "state": state,
+                    "xtuple_wo_id": wo_id,
+                    "xtuple_wo_number": wo_id,
+                }
+            )
+        )
+        return mo
+
+    def _make_imported_raw_moves(self, mo):
+        """Create imported raw moves mirroring the consumption importer:
+        ``raw_material_production_id`` + ``location_id = mo.location_src_id``,
+        ``xtuple_womatl_id`` set.  (Odoo 19's stock.move.create override forces
+        ``location_dest_id`` to the production location and back-propagates the
+        MO's production_group_id/reference_ids — same as the real import.)"""
+        type(self)._next_wo += 1
+        moves = self.env["stock.move"]
+        for i, (prod, qty) in enumerate(
+            [(self.comp_a, 2.0), (self.comp_b, 3.0)], start=1
+        ):
+            moves |= (
+                self.env["stock.move"]
+                .with_context(tracking_disable=True)
+                .create(
+                    {
+                        "raw_material_production_id": mo.id,
+                        "product_id": prod.id,
+                        "product_uom": self.uom_unit.id,
+                        "product_uom_qty": qty,
+                        "location_id": mo.location_src_id.id,
+                        "location_dest_id": self.prod_loc.id,
+                        "company_id": self.company.id,
+                        "warehouse_id": self.wh.id,
+                        # The real importer sets 'mts_else_mto' (a value the
+                        # mrp_mts_else_mto module adds and which is not installed
+                        # in this minimal test DB).  The move's own procure_method
+                        # is not load-bearing for PICK generation: action_confirm
+                        # runs _adjust_procure_method which re-derives it (and the
+                        # rule_id) from the live pbm route chain.
+                        "procure_method": "make_to_stock",
+                        "xtuple_womatl_id": type(self)._next_wo * 10 + i,
+                    }
+                )
+            )
+        return moves
+
+    def _run(self):
+        self.generator.generate_component_pickings(_make_ctx(self.env), {})
+
+    def _pbm_pickings(self, mo):
+        return mo.picking_ids.filtered(
+            lambda p: p.picking_type_id == self.wh.pbm_type_id
+        )
+
+    # ---- tests -----------------------------------------------------------
+
+    def test_ac1_pick_generated_on_full_import(self):
+        """AC1: an open/in-progress imported MO gets exactly one pbm-type PICK
+        automatically when the generator step runs (no manual re-run)."""
+        mo = self._make_imported_mo(state="progress")
+        raws = self._make_imported_raw_moves(mo)
+
+        self.assertFalse(self._pbm_pickings(mo), "no PICK should exist pre-run")
+        self._run()
+
+        picks = self._pbm_pickings(mo)
+        self.assertEqual(
+            len(picks), 1, "exactly one pbm-type PICK must be generated for the MO"
+        )
+        # The PICK feeds the pbm location (stock -> pre-production) and covers the
+        # MO's components.
+        pick = picks
+        self.assertEqual(pick.location_dest_id, self.wh.pbm_loc_id)
+        self.assertEqual(
+            set(pick.move_ids.mapped("product_id")),
+            set(raws.mapped("product_id")),
+            "PICK moves must cover the MO's imported components",
+        )
+
+    def test_ac2_raw_moves_not_doubled(self):
+        """AC2: the imported raw moves are not regenerated or doubled — the
+        same recordset (ids, count, qtys) survives the confirm."""
+        mo = self._make_imported_mo(state="progress")
+        raws = self._make_imported_raw_moves(mo)
+        before_ids = set(raws.ids)
+        before_qtys = {m.id: m.product_uom_qty for m in raws}
+
+        self._run()
+
+        after = mo.move_raw_ids
+        self.assertEqual(
+            set(after.ids), before_ids, "raw-move recordset must be unchanged (no doubling)"
+        )
+        self.assertEqual(len(after), 2)
+        for m in after:
+            self.assertEqual(m.product_uom_qty, before_qtys[m.id])
+        # No second consumption set created against this MO.
+        self.assertEqual(
+            self.env["stock.move"].search_count(
+                [("raw_material_production_id", "=", mo.id)]
+            ),
+            2,
+        )
+
+    def test_pick_chained_to_raw(self):
+        """The generated PICK chains into the MO's raw moves (stock -> pbm ->
+        production): each raw move's move_orig_ids includes a pbm pick move."""
+        mo = self._make_imported_mo(state="progress")
+        raws = self._make_imported_raw_moves(mo)
+        self._run()
+
+        for raw in raws:
+            origins = raw.move_orig_ids
+            self.assertTrue(
+                origins, f"raw move {raw.product_id.name} should be fed by a pick move"
+            )
+            self.assertTrue(
+                any(o.picking_type_id == self.wh.pbm_type_id for o in origins),
+                "the feeding move must be a pbm-type pick move",
+            )
+
+    def test_ac3_native_confirm_state_transition(self):
+        """AC3: generation uses the native confirm path.  A 'progress' MO keeps
+        its state (action_confirm only flips draft -> confirmed)."""
+        mo = self._make_imported_mo(state="progress")
+        self._make_imported_raw_moves(mo)
+        self._run()
+        self.assertEqual(mo.state, "progress")
+
+    def test_confirmed_mo_keeps_state(self):
+        """A 'confirmed' imported MO keeps its state and still gets its PICK."""
+        mo = self._make_imported_mo(state="confirmed")
+        self._make_imported_raw_moves(mo)
+        self._run()
+        self.assertEqual(mo.state, "confirmed")
+        self.assertEqual(len(self._pbm_pickings(mo)), 1)
+
+    def test_ac4_done_cancel_draft_untouched(self):
+        """AC4: done / cancel / draft MOs get no PICK from the generator."""
+        for state in ("done", "cancel", "draft"):
+            mo = self._make_imported_mo(state=state)
+            # draft can carry imported raw moves too; done/cancel are terminal.
+            if state == "draft":
+                self._make_imported_raw_moves(mo)
+            self._run()
+            self.assertFalse(
+                self._pbm_pickings(mo),
+                f"{state} MO must not get a component PICK",
+            )
+
+    def test_one_step_warehouse_no_pick(self):
+        """E2: if the warehouse has no pick step the generator is a no-op."""
+        self.wh.write({"manufacture_steps": "mrp_one_step"})
+        try:
+            mo = self._make_imported_mo(state="progress")
+            self._make_imported_raw_moves(mo)
+            self._run()
+            self.assertFalse(
+                mo.picking_ids,
+                "1-step manufacture warehouse must yield no component PICK",
+            )
+        finally:
+            self.wh.write({"manufacture_steps": "pbm"})
+
+    def test_idempotent_rerun(self):
+        """E3: running the generator twice yields exactly one PICK (no double
+        confirm, no duplicate PICK)."""
+        mo = self._make_imported_mo(state="progress")
+        self._make_imported_raw_moves(mo)
+        self._run()
+        first = self._pbm_pickings(mo)
+        self.assertEqual(len(first), 1)
+        # Re-run — must not create a second PICK nor a second pick-move set.
+        self._run()
+        second = self._pbm_pickings(mo)
+        self.assertEqual(set(second.ids), set(first.ids), "no second PICK on re-run")
+        self.assertEqual(
+            len(second.move_ids), len(first.move_ids), "no duplicate pick moves"
+        )
+
+    def test_no_imported_raw_moves_skip(self):
+        """E1: an open MO with zero imported raw moves -> no PICK, no error."""
+        mo = self._make_imported_mo(state="progress")
+        self._run()
+        self.assertFalse(self._pbm_pickings(mo))
+
+    def test_non_imported_mo_ignored(self):
+        """A native (non-imported) MO without xtuple_wo_id is never touched by
+        the generator (its scope is strictly imported MOs)."""
+        native = (
+            self.env["mrp.production"]
+            .with_context(tracking_disable=True)
+            .create(
+                {
+                    "product_id": self.finished.id,
+                    "product_uom_id": self.uom_unit.id,
+                    "product_qty": 1.0,
+                    "bom_id": self.bom.id,
+                }
+            )
+        )
+        self.assertEqual(native.state, "draft")
+        self._run()
+        # draft + no xtuple_wo_id: untouched, still draft, no PICK.
+        self.assertEqual(native.state, "draft")
+        self.assertFalse(
+            native.picking_ids.filtered(
+                lambda p: p.picking_type_id == self.wh.pbm_type_id
+            )
+        )


### PR DESCRIPTION
Vera task 3810 — REDESIGN per Marc's kickback: *"no-op at import is not acceptable. Find a way to get the picks in after a full import — configure cycle as in scripts/test_import.py. Make it automatic."* Supersedes #23 (rejected: no-op at import + manual re-run).

**Approach — native, automatic.** `scripts/test_import.py` configures the warehouse to `pbm` PRE-import, so by import time MOs already carry the pbm `location_src_id` and their raw moves carry `production_group_id`. The only missing step was confirming the MO. New load-only pipeline `xtuple.mrp.pick.generator` (`depends_on=['xtuple.mrp.consumption.importer']`) runs as the **final step of `action_import_all`** and calls native `action_confirm()` on each open/in-progress imported MO; the pbm pull rule then generates the component PICK natively (chain stock→pbm→production). No manual re-run, no duplicate activity.

**Safety (verified in Odoo-19 source):** only draft MOs change state (imported confirmed/progress keep theirs); `_compute_move_raw_ids` early-returns for non-draft so the BOM is never re-exploded (no doubled consumption); a pre-confirm `search_count` idempotency guard skips any MO that already has a pbm PICK. 12 tests green (10 new): PICK generated on full import, raw moves not doubled, pick chained to raw, idempotent re-run, done/cancel/draft excluded, native MOs untouched. Adversarial review: APPROVE.

**Live-smoke note (not a code defect):** the test fixture uses `make_to_stock`; the real importer writes `mts_else_mto` (mrp_mts_else_mto) — `action_confirm`'s `_adjust_procure_method` re-derives the rule from the live pbm route, but please eyeball PICKs on the FIRST real Verajet import (incl. one MIX + one BTL MO).