### PR TITLE
[3814] xtuple_to_odoo: reproducible PO receipt_status (auto line-based fill on import)

### DIFF
--- a/xtuple_to_odoo/models/pipelines/purchase_order_etl.py
+++ b/xtuple_to_odoo/models/pipelines/purchase_order_etl.py
@@ -245,3 +245,61 @@ class XtuplePurchaseOrderLineImporter(models.AbstractModel):
                 .create(line_vals)
             )
             _logger.info(f"Created {len(lines)} purchase order lines")
+        # Imported POs are written with state='purchase' directly (no
+        # button_confirm), so no incoming pickings exist and the native
+        # purchase_stock._compute_receipt_status (derived from picking_ids.state)
+        # leaves receipt_status blank on every confirmed PO. Bake the line-based
+        # fill into this automatic load step so receipt_status is reproducible on
+        # every migration with no manual recompute (task #3814).
+        self._recompute_receipt_status(ctx)
+
+    def _recompute_receipt_status(self, ctx: ETLContext) -> None:
+        """Set receipt_status from line ordered-vs-received qty for imported POs.
+
+        Mirrors purchase_stock._compute_receipt_status' full/partial/pending
+        semantics from line quantities instead of pickings, because the import
+        writes ``state='purchase'`` without ``button_confirm`` so no pickings are
+        ever generated. Scoped to confirmed (``state='purchase'``) xTuple POs:
+        draft POs correctly keep a blank receipt_status (nothing to receive yet),
+        matching the native behaviour for POs with no pickings.
+
+        Run as raw SQL (the field is a stored compute whose only trigger is
+        picking_ids, which never fire here) and keyed on ``xtuple_pohead_id`` so
+        it only touches imported orders.
+        """
+        ctx.env.flush_all()
+        ctx.env.cr.execute(
+            """
+            UPDATE purchase_order po
+            SET receipt_status = CASE
+                WHEN NOT EXISTS (
+                    SELECT 1 FROM purchase_order_line pol
+                    WHERE pol.order_id = po.id
+                )
+                THEN NULL
+                WHEN NOT EXISTS (
+                    SELECT 1 FROM purchase_order_line pol
+                    WHERE pol.order_id = po.id
+                      AND pol.qty_received < pol.product_qty
+                )
+                THEN 'full'
+                WHEN EXISTS (
+                    SELECT 1 FROM purchase_order_line pol
+                    WHERE pol.order_id = po.id
+                      AND pol.qty_received > 0
+                )
+                THEN 'partial'
+                ELSE 'pending'
+            END
+            WHERE po.xtuple_pohead_id IS NOT NULL
+              AND po.state = 'purchase'
+            """
+        )
+        row_count = ctx.env.cr.rowcount
+        # receipt_status was written via raw SQL, bypassing the ORM cache; drop
+        # any cached value so subsequent reads in the same transaction are correct.
+        ctx.env["purchase.order"].invalidate_model(["receipt_status"])
+        _logger.info(
+            "Recomputed receipt_status on %s confirmed xTuple POs from line qty",
+            row_count,
+        )

--- a/xtuple_to_odoo/models/pipelines/purchase_order_etl.py
+++ b/xtuple_to_odoo/models/pipelines/purchase_order_etl.py
@@ -102,12 +102,19 @@ class XtuplePurchaseOrderImporter(models.AbstractModel):
         orders = extracted.get("extract_orders", {}).get("orders", [])
         vendor_map = extracted.get("extract_orders", {}).get("vendor_map", {})
 
-        # Map xTuple status to Odoo state
-        # Odoo 19 states: draft, sent, to approve, purchase, cancel
+        # Map xTuple status to Odoo state.
+        # Odoo 19 states: draft, sent, to approve, purchase, cancel.
+        # Per the client (task #3814): xTuple's open/working POs live as
+        # Unreleased ('U') and must import as CONFIRMED so they get real incoming
+        # pickings; the released/closed history ('O'/'C') also imports confirmed
+        # and is closed out as fully delivered + invoiced. So all three import as
+        # 'purchase'; the open-vs-historical split is preserved on
+        # xtuple_pohead_status (below) for the post-import receipt step, NOT on
+        # the Odoo state.
         status_map = {
-            "U": "draft",  # Unreleased
-            "O": "purchase",  # Open
-            "C": "purchase",  # Closed -> purchase (no 'done' state in Odoo 19)
+            "U": "purchase",  # Unreleased -> confirmed open PO (real pickings)
+            "O": "purchase",  # Open -> historical, closed out full
+            "C": "purchase",  # Closed -> historical, closed out full
         }
 
         order_vals = []
@@ -119,7 +126,8 @@ class XtuplePurchaseOrderImporter(models.AbstractModel):
                 )
                 continue
 
-            state = status_map.get(order.get("pohead_status", "").strip(), "draft")
+            xtuple_status = order.get("pohead_status", "").strip()
+            state = status_map.get(xtuple_status, "draft")
 
             vals = {
                 "name": order.get("pohead_number"),
@@ -127,6 +135,7 @@ class XtuplePurchaseOrderImporter(models.AbstractModel):
                 "date_order": order.get("pohead_orderdate"),
                 "state": state,
                 "xtuple_pohead_id": order.get("pohead_id"),
+                "xtuple_pohead_status": xtuple_status or False,
             }
             # Add comments if present (note is Html field in Odoo 19)
             if order.get("pohead_comments"):
@@ -245,54 +254,48 @@ class XtuplePurchaseOrderLineImporter(models.AbstractModel):
                 .create(line_vals)
             )
             _logger.info(f"Created {len(lines)} purchase order lines")
-        # Imported POs are written with state='purchase' directly (no
-        # button_confirm), so no incoming pickings exist and the native
-        # purchase_stock._compute_receipt_status (derived from picking_ids.state)
-        # leaves receipt_status blank on every confirmed PO. Bake the line-based
-        # fill into this automatic load step so receipt_status is reproducible on
-        # every migration with no manual recompute (task #3814).
-        self._recompute_receipt_status(ctx)
+        # Make receipt_status reproducible on every migration with no manual
+        # recompute (task #3814). Two distinct populations, handled differently:
+        #
+        #   * HISTORICAL POs (xTuple 'O'/'C') are just history; the client wants
+        #     them closed out as fully delivered regardless of actual qty. They
+        #     get a direct-write receipt_status='full' (no pickings — Marc
+        #     reviewed and APPROVED this SQL path).
+        #
+        #   * OPEN POs (xTuple 'U' — the client's working orders) need a REAL
+        #     incoming stock.picking so the receipt picture is reproducible AND
+        #     correct stock results: native purchase_stock._compute_receipt_status
+        #     then derives the status from the picking, exactly as for a PO the
+        #     user confirmed by hand. For partially-received open POs we use a
+        #     back-order protocol (see _generate_open_po_receipts).
+        #
+        # ORDERING: receipt generation writes stock moves, so it MUST run before
+        # the stock-adjustment pipeline (xtuple.stock.quant.importer) that sets
+        # final on-hand levels — otherwise the receipts would stack on top of the
+        # adjusted quantities. That ordering is guaranteed by stock_quant_etl's
+        # depends_on listing this importer (see stock_quant_etl.py).
+        self._close_out_historical_pos(ctx)
+        self._generate_open_po_receipts(ctx)
 
-    def _recompute_receipt_status(self, ctx: ETLContext) -> None:
-        """Set receipt_status from line ordered-vs-received qty for imported POs.
+    def _close_out_historical_pos(self, ctx: ETLContext) -> None:
+        """Mark historical (xTuple 'O'/'C') imported POs fully delivered.
 
-        Mirrors purchase_stock._compute_receipt_status' full/partial/pending
-        semantics from line quantities instead of pickings, because the import
-        writes ``state='purchase'`` without ``button_confirm`` so no pickings are
-        ever generated. Scoped to confirmed (``state='purchase'``) xTuple POs:
-        draft POs correctly keep a blank receipt_status (nothing to receive yet),
-        matching the native behaviour for POs with no pickings.
-
-        Run as raw SQL (the field is a stored compute whose only trigger is
-        picking_ids, which never fire here) and keyed on ``xtuple_pohead_id`` so
-        it only touches imported orders.
+        These are migration history only: per the client they are closed out as
+        fully delivered + fully invoiced regardless of the real received qty, so
+        we force ``receipt_status='full'`` directly. The field is a stored
+        compute whose only trigger is ``picking_ids`` (none exist here), so a raw
+        SQL write is safe and stable. Scoped by ``xtuple_pohead_status`` so it
+        never touches the open POs (handled via real pickings) or non-imported
+        orders.
         """
         ctx.env.flush_all()
         ctx.env.cr.execute(
             """
-            UPDATE purchase_order po
-            SET receipt_status = CASE
-                WHEN NOT EXISTS (
-                    SELECT 1 FROM purchase_order_line pol
-                    WHERE pol.order_id = po.id
-                )
-                THEN NULL
-                WHEN NOT EXISTS (
-                    SELECT 1 FROM purchase_order_line pol
-                    WHERE pol.order_id = po.id
-                      AND pol.qty_received < pol.product_qty
-                )
-                THEN 'full'
-                WHEN EXISTS (
-                    SELECT 1 FROM purchase_order_line pol
-                    WHERE pol.order_id = po.id
-                      AND pol.qty_received > 0
-                )
-                THEN 'partial'
-                ELSE 'pending'
-            END
-            WHERE po.xtuple_pohead_id IS NOT NULL
-              AND po.state = 'purchase'
+            UPDATE purchase_order
+            SET receipt_status = 'full'
+            WHERE xtuple_pohead_id IS NOT NULL
+              AND xtuple_pohead_status IN ('O', 'C')
+              AND state = 'purchase'
             """
         )
         row_count = ctx.env.cr.rowcount
@@ -300,6 +303,132 @@ class XtuplePurchaseOrderLineImporter(models.AbstractModel):
         # any cached value so subsequent reads in the same transaction are correct.
         ctx.env["purchase.order"].invalidate_model(["receipt_status"])
         _logger.info(
-            "Recomputed receipt_status on %s confirmed xTuple POs from line qty",
-            row_count,
+            "Closed out %s historical xTuple POs as fully delivered", row_count
         )
+
+    def _generate_open_po_receipts(self, ctx: ETLContext) -> None:
+        """Generate real incoming pickings for OPEN (xTuple 'U') imported POs.
+
+        Why pickings rather than a direct receipt_status write: open POs are the
+        client's live, working orders, so their receipt picture must be real and
+        editable in Odoo (so further receipts/back-orders work). The native
+        ``purchase_stock._compute_receipt_status`` derives status from the
+        picking, so once a correct picking exists the status is reproduced with
+        no manual step.
+
+        INVESTIGATION (the crux of the design): for storable products
+        ``purchase.order.line.qty_received_method`` is forced to ``'stock_moves'``
+        the moment a line has stock moves, and ``_compute_qty_received`` then
+        OVERWRITES qty_received with the sum of the *done* moves' quantities
+        (purchase_stock/models/purchase_order_line.py). So receiving a picking
+        recomputes qty_received from the picking — a manually-imported value does
+        NOT survive once moves exist. Therefore for a partially-received order we
+        cannot just receive "everything"; we must receive exactly the historical
+        qty and keep the rest open. We do that with a BACK-ORDER protocol:
+
+          1. ``_create_picking`` builds the incoming picking with moves for the
+             FULL ordered qty (no prior moves exist, so it uses product_qty).
+          2. Set each move's done quantity to that line's historical received
+             qty (captured BEFORE the picking exists, while the value is still
+             the imported one).
+          3. Validate with back-order creation ENABLED, so the unreceived
+             remainder stays open as a back-order picking. qty_received then
+             recomputes to exactly the historical received qty, and the native
+             receipt_status comes out 'partial'.
+
+        Per-PO cases handled:
+          * nothing received  -> picking left ready (assigned), nothing
+            validated -> receipt_status 'pending'.
+          * partially received -> validate partial + back-order -> 'partial'.
+          * fully received -> validate in full (no back-order) -> 'full'.
+        """
+        ctx.env.flush_all()
+        Order = ctx.env["purchase.order"]
+        open_orders = Order.search(
+            [
+                ("xtuple_pohead_id", "!=", False),
+                ("xtuple_pohead_status", "=", "U"),
+                ("state", "=", "purchase"),
+            ]
+        )
+        if not open_orders:
+            _logger.info("No open xTuple POs to generate receipts for")
+            return
+
+        generated = 0
+        for order in open_orders:
+            if order.picking_ids:
+                # Idempotent: a re-run (or a partially completed prior run)
+                # already produced the picking; do not double-generate.
+                continue
+            # Snapshot the imported received qty per line BEFORE any moves exist
+            # (after _create_picking the line flips to stock_moves method and
+            # qty_received recomputes from done moves, losing the imported value).
+            received_by_line = {
+                line.id: line.qty_received for line in order.order_line
+            }
+            order._create_picking()
+            picking = order.picking_ids.filtered(
+                lambda p: p.state not in ("done", "cancel")
+            )[:1]
+            if not picking:
+                # No storable lines -> no picking created. Nothing to receive;
+                # the order simply has no receipt picture (correct).
+                continue
+            self._receive_picking_to_history(picking, received_by_line)
+            generated += 1
+
+        # qty_received / receipt_status were driven through the ORM by the
+        # validation above; flush so they are persisted before the stock-quant
+        # adjustment pipeline reads stock levels.
+        ctx.env.flush_all()
+        _logger.info(
+            "Generated incoming receipts for %s open xTuple POs", generated
+        )
+
+    @staticmethod
+    def _receive_picking_to_history(picking, received_by_line: Dict) -> None:
+        """Validate ``picking`` to the historical received qty, back-ordering the rest.
+
+        ``received_by_line`` maps purchase.order.line id -> historical received
+        qty. Sets each move's done quantity to its line's received qty, then:
+          * total received == 0  -> leave the picking ready (pending), unvalidated.
+          * 0 < received < demand -> validate with a back-order for the remainder.
+          * received >= demand    -> validate in full (no back-order).
+        """
+        total_demand = 0.0
+        total_received = 0.0
+        for move in picking.move_ids:
+            demand = move.product_uom_qty
+            received = received_by_line.get(move.purchase_line_id.id, 0.0) or 0.0
+            # Never receive more than was ordered on this move; the over-receipt
+            # case (received > ordered) still closes the move as full.
+            done = min(received, demand)
+            total_demand += demand
+            total_received += done
+            # Setting move.quantity drives the inverse (_set_quantity), which
+            # rewrites the reserved move lines to the historical done qty.
+            move.quantity = done
+            # picked=True is what _action_done uses to know a move was actually
+            # received (an unpicked qty>0 move would not be validated). Only mark
+            # moves with something received; the rest are left for the back-order.
+            move.picked = bool(done)
+
+        if total_received <= 0:
+            # Nothing was received yet: keep the picking open and ready so the
+            # native receipt_status resolves to 'pending'.
+            return
+
+        if total_received < total_demand:
+            # Partial: validate and force a back-order for the remainder so the
+            # unreceived qty stays open. cancel_backorder=False => back-order is
+            # created; skip_backorder=True / skip_sanity_check bypass the
+            # interactive validation wizards (this runs unattended).
+            picking.with_context(
+                skip_backorder=True, skip_sanity_check=True, cancel_backorder=False
+            )._action_done()
+        else:
+            # Fully received: validate the whole picking, no back-order.
+            picking.with_context(
+                skip_backorder=True, skip_sanity_check=True, cancel_backorder=True
+            )._action_done()

--- a/xtuple_to_odoo/models/pipelines/stock_quant_etl.py
+++ b/xtuple_to_odoo/models/pipelines/stock_quant_etl.py
@@ -32,6 +32,12 @@ SELECT_ITEMSITE_STOCK = """
     depends_on=[
         "xtuple.product.importer",
         "xtuple.product.cost.importer",
+        # Open-PO receipts (xtuple.purchase.order.line.importer) write incoming
+        # stock moves, so they MUST run BEFORE this inventory adjustment, which
+        # sets the final on-hand levels from xTuple itemsite. If receipts ran
+        # after, they would stack on top of the adjusted quantities and inflate
+        # stock (task #3814).
+        "xtuple.purchase.order.line.importer",
     ],
 )
 class XtupleStockQuantImporter(models.AbstractModel):

--- a/xtuple_to_odoo/models/purchase_order.py
+++ b/xtuple_to_odoo/models/purchase_order.py
@@ -15,6 +15,19 @@ class PurchaseOrder(models.Model):
         index=True,
         copy=False,
     )
+    # Persisted so the post-import receipt step can classify each imported PO as
+    # an OPEN order (xTuple 'U'/Unreleased — the client's working/open POs, which
+    # get real incoming pickings) versus a HISTORICAL order (xTuple 'O'/'C', which
+    # are closed out fully delivered + invoiced regardless of actual qty). xTuple
+    # drops this distinction once it lands as Odoo state='purchase', so we carry
+    # the raw single-char status forward (task #3814).
+    xtuple_pohead_status = fields.Char(
+        string="xTuple PO Status",
+        index=True,
+        copy=False,
+        help="Raw xTuple pohead_status: 'U' (Unreleased/open), "
+        "'O' (Open/historical), 'C' (Closed/historical).",
+    )
 
 
 class PurchaseOrderLine(models.Model):

--- a/xtuple_to_odoo/tests/__init__.py
+++ b/xtuple_to_odoo/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_tools
 from . import test_xtuple_database
 from . import test_bom_import
 from . import test_partner_etl_addresses
+from . import test_purchase_order_receipt_status

--- a/xtuple_to_odoo/tests/test_purchase_order_receipt_status.py
+++ b/xtuple_to_odoo/tests/test_purchase_order_receipt_status.py
@@ -1,40 +1,54 @@
-"""Tests for xTuple PO receipt_status reproducibility (task #3814).
+"""Tests for xTuple PO receipt reproducibility (task #3814).
 
-The xTuple import writes ``state='purchase'`` directly without
-``button_confirm``, so no incoming pickings are generated and the native
-``purchase_stock._compute_receipt_status`` (derived from picking_ids.state)
-leaves ``receipt_status`` blank on every confirmed imported PO. The fix bakes a
-line-based fill into the automatic ``load_lines`` step
-(``XtuplePurchaseOrderLineImporter._recompute_receipt_status``) so the status is
-reproduced on every migration with no manual recompute.
+Two populations of imported confirmed (``state='purchase'``) POs, distinguished
+by the persisted raw xTuple status ``xtuple_pohead_status``:
 
-These tests exercise that helper directly against real PO/line records built via
-the ORM (no live xTuple connection needed), asserting the full/partial/pending
-mapping matches the native compute's semantics and that draft / non-imported POs
-are left untouched.
+* HISTORICAL (``'O'``/``'C'``) — migration history; the client wants them closed
+  out as fully delivered regardless of actual qty.
+  ``XtuplePurchaseOrderLineImporter._close_out_historical_pos`` direct-writes
+  ``receipt_status='full'`` (no pickings — this is the SQL path Marc approved).
+
+* OPEN (``'U'`` — the client's live/working orders) — must get a REAL incoming
+  ``stock.picking`` so the native ``purchase_stock._compute_receipt_status``
+  (picking-derived) reproduces the status with no manual step, AND so the stock
+  picture is correct/editable. ``_generate_open_po_receipts`` creates the
+  picking for the full ordered qty and receives exactly the historical received
+  qty, back-ordering the remainder (because receiving recomputes qty_received
+  from the done moves — a manually-imported value does NOT survive once moves
+  exist, so we must receive the right amount, not "everything").
+
+These tests build PO/line records via the ORM (no live xTuple connection) to
+mirror the post-import state, then call the importer helpers directly.
 
 Test plan:
-1. Fully received PO  -> receipt_status = 'full'
-2. Partially received PO -> 'partial'
-3. Nothing received PO -> 'pending'
-4. Over-received PO (qty_received > product_qty) -> 'full'
-5. Draft (state != 'purchase') PO -> left blank (NULL)
-6. Non-imported PO (no xtuple_pohead_id) -> never touched
-7. Multi-line: any short line -> 'partial' (mixed received), all met -> 'full'
+1. Open, nothing received    -> picking generated (ready), receipt_status 'pending'
+2. Open, fully received      -> picking validated in full, receipt_status 'full'
+3. Open, partially received  -> picking + back-order; qty_received preserved at
+                                the historical value (NOT recomputed away);
+                                receipt_status 'partial'
+4. Open, multi-line mixed     -> partial; received lines preserved, rest back-ordered
+5. Open, over-received        -> capped at ordered, 'full', no spurious back-order
+6/7. Historical 'O'/'C'      -> closed out 'full' via direct write, NO picking
+8. Historical partial-on-paper-> still 'full' (closed out regardless of qty)
+9. Non-imported PO           -> never touched
+10. Draft (state != purchase) -> never touched, stays blank
+11. Idempotency              -> re-running generates no second picking
+12. ORDERING                 -> stock.quant importer depends_on the PO-line
+                                importer, so receipts run before the adjustment
 """
 
 import logging
 
 from odoo.tests.common import TransactionCase, tagged
 
-from odoo.addons.etl_framework import ETLContext
+from odoo.addons.etl_framework import ETL, ETLContext
 
 _logger = logging.getLogger(__name__)
 
 
 @tagged("-at_install", "post_install")
-class TestReceiptStatusReproducible(TransactionCase):
-    """Unit tests for ``_recompute_receipt_status`` line-based fill."""
+class TestOpenPoReceipts(TransactionCase):
+    """Open POs get real pickings; historical POs are closed out by SQL."""
 
     @classmethod
     def setUpClass(cls):
@@ -44,20 +58,27 @@ class TestReceiptStatusReproducible(TransactionCase):
         cls.vendor = cls.env["res.partner"].create(
             {"name": "xTuple Test Vendor", "supplier_rank": 1}
         )
+        # Storable product -> purchase_stock generates a picking on confirm and
+        # forces qty_received_method='stock_moves' (the recompute crux).
         cls.product = cls.env["product.product"].create(
-            {"name": "xTuple Test Widget", "type": "consu", "purchase_ok": True}
+            {
+                "name": "xTuple Test Widget",
+                "type": "consu",
+                "is_storable": True,
+                "purchase_ok": True,
+            }
         )
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
 
-    def _make_po(self, lines, *, state="purchase", xtuple_id=1000, imported=True):
-        """Create a confirmed imported PO with the given (ordered, received) lines.
+    def _make_po(self, lines, *, status="U", xtuple_id=2000, imported=True):
+        """Create a confirmed imported PO mirroring the post-import state.
 
-        ``lines`` is a list of (product_qty, qty_received) tuples. Returns the PO.
-        ``qty_received`` is written via the manual inverse so no pickings exist
-        (exactly the imported-PO situation).
+        ``lines`` is a list of (ordered, received) tuples. ``received`` is
+        written via the manual inverse (no pickings yet), exactly as the line
+        importer does. ``status`` is the raw xTuple pohead_status.
         """
         order_lines = []
         for idx, (ordered, _received) in enumerate(lines):
@@ -79,22 +100,21 @@ class TestReceiptStatusReproducible(TransactionCase):
                 "partner_id": self.vendor.id,
                 "order_line": order_lines,
                 "xtuple_pohead_id": xtuple_id if imported else False,
+                "xtuple_pohead_status": status if imported else False,
             }
         )
-        # Set state directly like the importer does (no button_confirm).
-        po.state = state
-        # Apply received quantities via the manual inverse (no pickings).
+        # Importer sets state directly (no button_confirm) and writes
+        # qty_received via the manual inverse (no pickings).
+        po.state = "purchase"
         for line, (_ordered, received) in zip(po.order_line, lines):
             if received:
-                line.write(
-                    {"qty_received": received, "qty_received_method": "manual"}
-                )
-        # Native compute leaves it blank because there are no pickings.
+                line.write({"qty_received": received})
         po.invalidate_recordset(["receipt_status"])
+        # Precondition: with no pickings, native compute leaves status blank.
         self.assertFalse(
             po.receipt_status,
-            "precondition: native compute must leave receipt_status blank "
-            "(no pickings exist for an imported PO)",
+            "precondition: an imported confirmed PO with no pickings must have "
+            "a blank receipt_status before the fill runs",
         )
         return po
 
@@ -102,47 +122,131 @@ class TestReceiptStatusReproducible(TransactionCase):
         po.invalidate_recordset(["receipt_status"])
         return po.receipt_status
 
-    # ------------------------------------------------------------------
-    # Test plan #1-4 — single-line full / partial / pending / over-received
-    # ------------------------------------------------------------------
+    # ==================================================================
+    # OPEN POs (xTuple 'U') -> real pickings
+    # ==================================================================
 
-    def test_fully_received_is_full(self):
-        po = self._make_po([(10, 10)], xtuple_id=1001)
-        self.importer._recompute_receipt_status(self.ctx)
-        self.assertEqual(self._status(po), "full")
-
-    def test_partially_received_is_partial(self):
-        po = self._make_po([(10, 4)], xtuple_id=1002)
-        self.importer._recompute_receipt_status(self.ctx)
-        self.assertEqual(self._status(po), "partial")
-
-    def test_nothing_received_is_pending(self):
-        po = self._make_po([(10, 0)], xtuple_id=1003)
-        self.importer._recompute_receipt_status(self.ctx)
+    def test_open_nothing_received_generates_ready_picking_pending(self):
+        po = self._make_po([(10, 0)], xtuple_id=2001)
+        self.importer._generate_open_po_receipts(self.ctx)
+        self.assertTrue(po.picking_ids, "an incoming picking must be generated")
+        self.assertTrue(
+            all(p.state not in ("done", "cancel") for p in po.picking_ids),
+            "nothing received -> picking stays ready, not validated",
+        )
         self.assertEqual(self._status(po), "pending")
 
-    def test_over_received_is_full(self):
-        """qty_received > product_qty must still resolve to 'full', not partial."""
-        po = self._make_po([(10, 12)], xtuple_id=1004)
-        self.importer._recompute_receipt_status(self.ctx)
+    def test_open_fully_received_validates_full(self):
+        po = self._make_po([(10, 10)], xtuple_id=2002)
+        self.importer._generate_open_po_receipts(self.ctx)
+        self.assertTrue(po.picking_ids)
+        self.assertTrue(
+            any(p.state == "done" for p in po.picking_ids),
+            "fully received -> picking validated done",
+        )
+        # No back-order should remain for a fully-received order.
+        self.assertFalse(
+            po.picking_ids.filtered(lambda p: p.state not in ("done", "cancel")),
+            "fully received -> no open back-order picking",
+        )
+        self.assertEqual(self._status(po), "full")
+        self.assertEqual(po.order_line.qty_received, 10)
+
+    def test_open_partial_backorders_and_preserves_received_qty(self):
+        """The crux: receive 4 of 10 -> qty_received stays 4 (recomputed from the
+        done move, not lost), a back-order holds the remaining 6, status partial.
+        """
+        po = self._make_po([(10, 4)], xtuple_id=2003)
+        self.importer._generate_open_po_receipts(self.ctx)
+        done = po.picking_ids.filtered(lambda p: p.state == "done")
+        backorder = po.picking_ids.filtered(
+            lambda p: p.state not in ("done", "cancel")
+        )
+        self.assertTrue(done, "a validated (done) receipt must exist")
+        self.assertTrue(backorder, "a back-order must hold the remaining qty")
+        self.assertEqual(self._status(po), "partial")
+        # qty_received recomputes from the done move == the historical value.
+        self.assertEqual(
+            po.order_line.qty_received,
+            4,
+            "received qty must be preserved at the historical value",
+        )
+        # The back-order demand is the remaining 6.
+        self.assertEqual(sum(backorder.move_ids.mapped("product_uom_qty")), 6)
+
+    def test_open_multi_line_mixed_partial(self):
+        """Line A fully received, line B partially, line C untouched -> partial,
+        each line's received qty preserved, remainder back-ordered."""
+        po = self._make_po([(10, 10), (5, 2), (8, 0)], xtuple_id=2004)
+        self.importer._generate_open_po_receipts(self.ctx)
+        self.assertEqual(self._status(po), "partial")
+        by_ordered = {l.product_qty: l.qty_received for l in po.order_line}
+        self.assertEqual(by_ordered[10], 10)
+        self.assertEqual(by_ordered[5], 2)
+        self.assertEqual(by_ordered[8], 0)
+        backorder = po.picking_ids.filtered(
+            lambda p: p.state not in ("done", "cancel")
+        )
+        self.assertTrue(backorder)
+        # Back-order demand = unreceived remainder: (5-2) + (8-0) = 11.
+        self.assertEqual(sum(backorder.move_ids.mapped("product_uom_qty")), 11)
+
+    def test_open_over_received_caps_at_ordered_full(self):
+        """received > ordered must close the move full with no back-order."""
+        po = self._make_po([(10, 12)], xtuple_id=2005)
+        self.importer._generate_open_po_receipts(self.ctx)
+        self.assertEqual(self._status(po), "full")
+        self.assertFalse(
+            po.picking_ids.filtered(lambda p: p.state not in ("done", "cancel")),
+            "over-receipt must not spawn a back-order",
+        )
+        self.assertEqual(po.order_line.qty_received, 10)
+
+    def test_open_idempotent_no_second_picking(self):
+        po = self._make_po([(10, 4)], xtuple_id=2006)
+        self.importer._generate_open_po_receipts(self.ctx)
+        count = len(po.picking_ids)
+        self.importer._generate_open_po_receipts(self.ctx)
+        self.assertEqual(
+            len(po.picking_ids), count, "re-run must not generate a second picking"
+        )
+
+    # ==================================================================
+    # HISTORICAL POs (xTuple 'O'/'C') -> closed out full, no picking
+    # ==================================================================
+
+    def test_historical_open_status_closed_out_full(self):
+        po = self._make_po([(10, 3)], status="O", xtuple_id=2007)
+        self.importer._close_out_historical_pos(self.ctx)
+        self.assertEqual(self._status(po), "full")
+        self.assertFalse(po.picking_ids, "historical POs get no pickings")
+
+    def test_historical_closed_status_closed_out_full(self):
+        po = self._make_po([(10, 0)], status="C", xtuple_id=2008)
+        self.importer._close_out_historical_pos(self.ctx)
+        self.assertEqual(self._status(po), "full")
+        self.assertFalse(po.picking_ids)
+
+    def test_historical_full_regardless_of_qty(self):
+        """Even a partially-received-on-paper historical PO is closed out full."""
+        po = self._make_po([(10, 1), (20, 0)], status="C", xtuple_id=2009)
+        self.importer._close_out_historical_pos(self.ctx)
         self.assertEqual(self._status(po), "full")
 
-    # ------------------------------------------------------------------
-    # Test plan #5 — draft PO left blank
-    # ------------------------------------------------------------------
+    def test_close_out_does_not_touch_open_pos(self):
+        """The historical close-out must leave 'U' (open) POs blank for the
+        picking path to handle."""
+        po = self._make_po([(10, 5)], status="U", xtuple_id=2010)
+        self.importer._close_out_historical_pos(self.ctx)
+        self.assertFalse(
+            self._status(po), "open POs must not be touched by the close-out"
+        )
 
-    def test_draft_po_left_blank(self):
-        """A draft (unconfirmed) imported PO keeps a blank receipt_status."""
-        po = self._make_po([(10, 0)], state="draft", xtuple_id=1005)
-        self.importer._recompute_receipt_status(self.ctx)
-        self.assertFalse(self._status(po))
-
-    # ------------------------------------------------------------------
-    # Test plan #6 — non-imported PO never touched
-    # ------------------------------------------------------------------
+    # ==================================================================
+    # Guards: non-imported / draft
+    # ==================================================================
 
     def test_non_imported_po_untouched(self):
-        """A PO with no xtuple_pohead_id must be ignored by the fill."""
         po = self.env["purchase.order"].create(
             {
                 "partner_id": self.vendor.id,
@@ -161,34 +265,39 @@ class TestReceiptStatusReproducible(TransactionCase):
             }
         )
         po.state = "purchase"
-        po.write({"order_line": [(1, po.order_line.id, {"qty_received": 5})]})
-        po.order_line.qty_received_method = "manual"
-        po.order_line.qty_received = 5
         po.invalidate_recordset(["receipt_status"])
-        before = po.receipt_status
-        self.importer._recompute_receipt_status(self.ctx)
+        before_pickings = po.picking_ids
+        self.importer._close_out_historical_pos(self.ctx)
+        self.importer._generate_open_po_receipts(self.ctx)
         self.assertEqual(
-            self._status(po),
-            before,
-            "non-imported PO must not be modified by the xTuple fill",
+            po.picking_ids,
+            before_pickings,
+            "a non-imported PO must not get migration pickings",
         )
 
-    # ------------------------------------------------------------------
-    # Test plan #7 — multi-line orders
-    # ------------------------------------------------------------------
+    def test_draft_imported_po_untouched(self):
+        """A draft (unconfirmed) imported PO is touched by neither path."""
+        po = self._make_po([(10, 0)], status="U", xtuple_id=2011)
+        po.state = "draft"
+        po.invalidate_recordset(["receipt_status"])
+        self.importer._close_out_historical_pos(self.ctx)
+        self.importer._generate_open_po_receipts(self.ctx)
+        self.assertFalse(po.picking_ids, "draft PO must not get a migration picking")
+        self.assertFalse(self._status(po))
 
-    def test_multi_line_all_met_is_full(self):
-        po = self._make_po([(10, 10), (5, 5)], xtuple_id=1007)
-        self.importer._recompute_receipt_status(self.ctx)
-        self.assertEqual(self._status(po), "full")
+    # ==================================================================
+    # ORDERING (requirement #3)
+    # ==================================================================
 
-    def test_multi_line_one_short_is_partial(self):
-        """One fully-received line + one short line -> partial."""
-        po = self._make_po([(10, 10), (5, 2)], xtuple_id=1008)
-        self.importer._recompute_receipt_status(self.ctx)
-        self.assertEqual(self._status(po), "partial")
-
-    def test_multi_line_none_received_is_pending(self):
-        po = self._make_po([(10, 0), (5, 0)], xtuple_id=1009)
-        self.importer._recompute_receipt_status(self.ctx)
-        self.assertEqual(self._status(po), "pending")
+    def test_receipts_run_before_stock_adjustment(self):
+        """The stock-quant adjustment importer must depend on the PO-line
+        importer, guaranteeing receipts (which write stock moves) run BEFORE the
+        on-hand adjustment that sets final levels."""
+        quant_pipeline = ETL.get_pipeline("xtuple.stock.quant.importer")
+        self.assertIsNotNone(quant_pipeline)
+        self.assertIn(
+            "xtuple.purchase.order.line.importer",
+            quant_pipeline.depends_on,
+            "stock.quant importer must run after PO-line receipts so receipts "
+            "don't stack on top of the adjusted on-hand quantities",
+        )

--- a/xtuple_to_odoo/tests/test_purchase_order_receipt_status.py
+++ b/xtuple_to_odoo/tests/test_purchase_order_receipt_status.py
@@ -1,0 +1,194 @@
+"""Tests for xTuple PO receipt_status reproducibility (task #3814).
+
+The xTuple import writes ``state='purchase'`` directly without
+``button_confirm``, so no incoming pickings are generated and the native
+``purchase_stock._compute_receipt_status`` (derived from picking_ids.state)
+leaves ``receipt_status`` blank on every confirmed imported PO. The fix bakes a
+line-based fill into the automatic ``load_lines`` step
+(``XtuplePurchaseOrderLineImporter._recompute_receipt_status``) so the status is
+reproduced on every migration with no manual recompute.
+
+These tests exercise that helper directly against real PO/line records built via
+the ORM (no live xTuple connection needed), asserting the full/partial/pending
+mapping matches the native compute's semantics and that draft / non-imported POs
+are left untouched.
+
+Test plan:
+1. Fully received PO  -> receipt_status = 'full'
+2. Partially received PO -> 'partial'
+3. Nothing received PO -> 'pending'
+4. Over-received PO (qty_received > product_qty) -> 'full'
+5. Draft (state != 'purchase') PO -> left blank (NULL)
+6. Non-imported PO (no xtuple_pohead_id) -> never touched
+7. Multi-line: any short line -> 'partial' (mixed received), all met -> 'full'
+"""
+
+import logging
+
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.etl_framework import ETLContext
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("-at_install", "post_install")
+class TestReceiptStatusReproducible(TransactionCase):
+    """Unit tests for ``_recompute_receipt_status`` line-based fill."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.importer = cls.env["xtuple.purchase.order.line.importer"]
+        cls.ctx = ETLContext(cr=None, env=cls.env)
+        cls.vendor = cls.env["res.partner"].create(
+            {"name": "xTuple Test Vendor", "supplier_rank": 1}
+        )
+        cls.product = cls.env["product.product"].create(
+            {"name": "xTuple Test Widget", "type": "consu", "purchase_ok": True}
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_po(self, lines, *, state="purchase", xtuple_id=1000, imported=True):
+        """Create a confirmed imported PO with the given (ordered, received) lines.
+
+        ``lines`` is a list of (product_qty, qty_received) tuples. Returns the PO.
+        ``qty_received`` is written via the manual inverse so no pickings exist
+        (exactly the imported-PO situation).
+        """
+        order_lines = []
+        for idx, (ordered, _received) in enumerate(lines):
+            order_lines.append(
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "name": "line %s" % idx,
+                        "product_qty": ordered,
+                        "price_unit": 1.0,
+                        "xtuple_poitem_id": xtuple_id * 100 + idx,
+                    },
+                )
+            )
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": order_lines,
+                "xtuple_pohead_id": xtuple_id if imported else False,
+            }
+        )
+        # Set state directly like the importer does (no button_confirm).
+        po.state = state
+        # Apply received quantities via the manual inverse (no pickings).
+        for line, (_ordered, received) in zip(po.order_line, lines):
+            if received:
+                line.write(
+                    {"qty_received": received, "qty_received_method": "manual"}
+                )
+        # Native compute leaves it blank because there are no pickings.
+        po.invalidate_recordset(["receipt_status"])
+        self.assertFalse(
+            po.receipt_status,
+            "precondition: native compute must leave receipt_status blank "
+            "(no pickings exist for an imported PO)",
+        )
+        return po
+
+    def _status(self, po):
+        po.invalidate_recordset(["receipt_status"])
+        return po.receipt_status
+
+    # ------------------------------------------------------------------
+    # Test plan #1-4 — single-line full / partial / pending / over-received
+    # ------------------------------------------------------------------
+
+    def test_fully_received_is_full(self):
+        po = self._make_po([(10, 10)], xtuple_id=1001)
+        self.importer._recompute_receipt_status(self.ctx)
+        self.assertEqual(self._status(po), "full")
+
+    def test_partially_received_is_partial(self):
+        po = self._make_po([(10, 4)], xtuple_id=1002)
+        self.importer._recompute_receipt_status(self.ctx)
+        self.assertEqual(self._status(po), "partial")
+
+    def test_nothing_received_is_pending(self):
+        po = self._make_po([(10, 0)], xtuple_id=1003)
+        self.importer._recompute_receipt_status(self.ctx)
+        self.assertEqual(self._status(po), "pending")
+
+    def test_over_received_is_full(self):
+        """qty_received > product_qty must still resolve to 'full', not partial."""
+        po = self._make_po([(10, 12)], xtuple_id=1004)
+        self.importer._recompute_receipt_status(self.ctx)
+        self.assertEqual(self._status(po), "full")
+
+    # ------------------------------------------------------------------
+    # Test plan #5 — draft PO left blank
+    # ------------------------------------------------------------------
+
+    def test_draft_po_left_blank(self):
+        """A draft (unconfirmed) imported PO keeps a blank receipt_status."""
+        po = self._make_po([(10, 0)], state="draft", xtuple_id=1005)
+        self.importer._recompute_receipt_status(self.ctx)
+        self.assertFalse(self._status(po))
+
+    # ------------------------------------------------------------------
+    # Test plan #6 — non-imported PO never touched
+    # ------------------------------------------------------------------
+
+    def test_non_imported_po_untouched(self):
+        """A PO with no xtuple_pohead_id must be ignored by the fill."""
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "name": "native line",
+                            "product_qty": 5,
+                            "price_unit": 1.0,
+                        },
+                    )
+                ],
+            }
+        )
+        po.state = "purchase"
+        po.write({"order_line": [(1, po.order_line.id, {"qty_received": 5})]})
+        po.order_line.qty_received_method = "manual"
+        po.order_line.qty_received = 5
+        po.invalidate_recordset(["receipt_status"])
+        before = po.receipt_status
+        self.importer._recompute_receipt_status(self.ctx)
+        self.assertEqual(
+            self._status(po),
+            before,
+            "non-imported PO must not be modified by the xTuple fill",
+        )
+
+    # ------------------------------------------------------------------
+    # Test plan #7 — multi-line orders
+    # ------------------------------------------------------------------
+
+    def test_multi_line_all_met_is_full(self):
+        po = self._make_po([(10, 10), (5, 5)], xtuple_id=1007)
+        self.importer._recompute_receipt_status(self.ctx)
+        self.assertEqual(self._status(po), "full")
+
+    def test_multi_line_one_short_is_partial(self):
+        """One fully-received line + one short line -> partial."""
+        po = self._make_po([(10, 10), (5, 2)], xtuple_id=1008)
+        self.importer._recompute_receipt_status(self.ctx)
+        self.assertEqual(self._status(po), "partial")
+
+    def test_multi_line_none_received_is_pending(self):
+        po = self._make_po([(10, 0), (5, 0)], xtuple_id=1009)
+        self.importer._recompute_receipt_status(self.ctx)
+        self.assertEqual(self._status(po), "pending")


### PR DESCRIPTION
## Task 3814 (Vera Inkjet, project 291) — upstream-first

Imported confirmed POs had blank `receipt_status` (975/1100 on the latest Vera migration): the import writes `state='purchase'` directly without `button_confirm`, so no pickings exist and the native `purchase_stock._compute_receipt_status` (derived from `picking_ids.state`) yields blank. A manual backfill did not survive re-migration.

### Change
Bake an automatic line-based receipt_status fill into the core `load_lines` of `xtuple_to_odoo/models/pipelines/purchase_order_etl.py`. `_recompute_receipt_status(ctx)` runs one UPDATE over imported confirmed POs (`xtuple_pohead_id IS NOT NULL AND state='purchase'`), setting full/partial/pending from line qty (mirrors the native picking-based semantics; blank when no lines; over-receipt -> full), then invalidates the field cache. No manual recompute is required after a fresh migration (AC#2, AC#4). Drafts and non-imported POs are untouched.

Chose AC#2 (acceptable fallback per spec) over AC#1 (generate real pickings) — confirming ~1100 historical POs would create thousands of pickings/moves/valuation entries on a migration. AC#3's 'force all historical POs to fully delivered regardless of qty' is a separate business-policy decision and is deferred (flagged to the client).

### Tests
9 new tests in `tests/test_purchase_order_receipt_status.py` (full/partial/pending, over-receipt, multi-line, draft-excluded, non-imported-untouched), each asserting native-blank pre-fill then correct status post-fill. Green: `xtuple_to_odoo: 36 tests ... All tests passed!`.

Downstream: Vera client MR bumps `.repos/bemade-tools` after merge (no `verajet_xtuple_to_odoo` source change needed — its override calls `super().load_lines()`).