### PR TITLE
sap_b1_to_odoo: import SAP stock locations (OITM.sww) + place quants by sww

### DIFF
--- a/sap_b1_to_odoo/models/__init__.py
+++ b/sap_b1_to_odoo/models/__init__.py
@@ -11,6 +11,7 @@ from . import carrier_account
 from . import product_pricelist
 from . import stock_picking
 from . import stock_warehouse
+from . import stock_location
 from . import res_users
 from . import account_payment_term
 from . import ir_attachment

--- a/sap_b1_to_odoo/models/pipelines/__init__.py
+++ b/sap_b1_to_odoo/models/pipelines/__init__.py
@@ -5,6 +5,7 @@ from . import product_product_etl
 from . import customer_product_code_etl
 from . import ir_attachment_etl
 from . import stock_warehouse_etl
+from . import stock_location_etl
 from . import stock_quant_etl
 # Disabled: stock.valuation.layer model removed in Odoo 19, needs rewrite
 # from . import stock_valuation_etl

--- a/sap_b1_to_odoo/models/pipelines/stock_location_etl.py
+++ b/sap_b1_to_odoo/models/pipelines/stock_location_etl.py
@@ -1,0 +1,169 @@
+#
+#    Bemade Inc.
+#
+#    Copyright (C) 2024-June Bemade Inc. (<https://www.bemade.org>).
+#    Author: Marc Durepos (Contact : marc@bemade.org)
+#
+#    This program is under the terms of the GNU Lesser General Public License,
+#    version 3.
+#
+#    For full license details, see https://www.gnu.org/licenses/lgpl-3.0.en.html.
+#
+import logging
+from typing import Dict, List
+
+from odoo import models
+
+from odoo.addons.etl_framework import ETL, ETLContext
+
+_logger = logging.getLogger(__name__)
+
+
+@ETL.pipeline(
+    target_model="stock.location",
+    importer_name="stock.location.importer",
+    sap_source="oitm",
+    depends_on=["stock.warehouse.importer"],
+    allow_multiprocessing=False,
+)
+class StockLocationImporter(models.AbstractModel):
+    _name = "stock.location.importer"
+    _description = "SAP Stock Location Importer (OITM.sww)"
+
+    @ETL.extract("oitm")
+    def extract_stock_locations(self, ctx: ETLContext) -> Dict:
+        """Extract distinct non-empty sww codes from SAP OITM.
+
+        Args:
+            ctx: ETL context with SAP cursor and Odoo environment.
+
+        Returns:
+            Dict containing distinct sww codes and the warehouse lot_stock_id mapping.
+        """
+        sql = """
+            SELECT DISTINCT sww
+            FROM oitm
+            WHERE sww IS NOT NULL
+              AND sww <> ''
+        """
+        ctx.cr.execute(sql)
+        rows = ctx.cr.dictfetchall()
+        sww_codes = [r["sww"].strip() for r in rows if (r.get("sww") or "").strip()]
+
+        # Build warehouse → lot_stock_id map (keyed by sap_whs_code)
+        warehouses = ctx.env["stock.warehouse"].search([("active", "=", True)])
+        warehouse_lot_stock_map = {
+            wh.sap_whs_code: wh.lot_stock_id.id
+            for wh in warehouses
+            if wh.sap_whs_code and wh.lot_stock_id
+        }
+
+        _logger.info(
+            "Extracted %d distinct non-empty sww codes from SAP OITM.", len(sww_codes)
+        )
+        return {
+            "sww_codes": sww_codes,
+            "warehouse_lot_stock_map": warehouse_lot_stock_map,
+        }
+
+    @ETL.transform()
+    def transform_stock_locations(self, ctx: ETLContext, extracted: Dict) -> List[Dict]:
+        """Transform sww codes into stock.location value dicts.
+
+        Each distinct sww code becomes one internal location.  The parent
+        location is the warehouse's lot_stock_id.  If the warehouse map has
+        only one entry (single-warehouse setup), that entry is used for all
+        locations.  If the map is empty, a warning is logged and no locations
+        are produced.
+
+        Args:
+            ctx: ETL context.
+            extracted: Dict from extract_stock_locations.
+
+        Returns:
+            List of stock.location value dicts ready for upsert.
+        """
+        data = extracted.get("extract_stock_locations") or {}
+        sww_codes = data.get("sww_codes", [])
+        warehouse_lot_stock_map = data.get("warehouse_lot_stock_map", {})
+
+        if not warehouse_lot_stock_map:
+            _logger.warning(
+                "stock_location transform: no warehouses with sap_whs_code found — "
+                "cannot determine parent lot_stock_id; skipping all sww locations."
+            )
+            return []
+
+        # For a single-warehouse installation, use that warehouse's lot_stock_id
+        # as the parent for every sww location.
+        if len(warehouse_lot_stock_map) == 1:
+            default_lot_stock_id = next(iter(warehouse_lot_stock_map.values()))
+        else:
+            # Multi-warehouse: use the first entry as default (caller can override
+            # via a client overlay if needed).
+            default_lot_stock_id = next(iter(warehouse_lot_stock_map.values()))
+            _logger.info(
+                "stock_location transform: multiple warehouses found; using first "
+                "warehouse lot_stock_id (%d) as parent for all sww locations.",
+                default_lot_stock_id,
+            )
+
+        location_vals = []
+        for sww in sww_codes:
+            vals = {
+                "name": sww,
+                "usage": "internal",
+                "location_id": default_lot_stock_id,
+                "sap_sww_code": sww,
+                "active": True,
+            }
+            location_vals.append(vals)
+
+        _logger.info(
+            "Transformed %d stock.location records for sww codes.", len(location_vals)
+        )
+        return location_vals
+
+    @ETL.load()
+    def load_stock_locations(self, ctx: ETLContext, transformed: Dict) -> None:
+        """Upsert stock.location records keyed on sap_sww_code.
+
+        Existing locations are updated; new sww codes create new locations.
+        Idempotent: re-running with the same data produces no duplicates.
+
+        Args:
+            ctx: ETL context.
+            transformed: Dict from transform_stock_locations.
+        """
+        location_vals = transformed.get("transform_stock_locations") or []
+
+        if not location_vals:
+            _logger.info("No sww stock locations to upsert.")
+            return
+
+        # Build lookup of existing locations keyed by sap_sww_code
+        existing = {
+            loc["sap_sww_code"]: loc["id"]
+            for loc in ctx.env["stock.location"].with_context(active_test=False).search_read(
+                [("sap_sww_code", "!=", False)],
+                ["sap_sww_code"],
+            )
+        }
+
+        to_create = []
+        to_write = []  # list of (id, vals)
+        for vals in location_vals:
+            sww = vals["sap_sww_code"]
+            if sww in existing:
+                to_write.append((existing[sww], vals))
+            else:
+                to_create.append(vals)
+
+        if to_create:
+            locations = ctx.env["stock.location"].create(to_create)
+            _logger.info("Created %d stock.location records for sww codes.", len(locations))
+
+        if to_write:
+            for loc_id, vals in to_write:
+                ctx.env["stock.location"].browse(loc_id).write(vals)
+            _logger.info("Updated %d existing stock.location records.", len(to_write))

--- a/sap_b1_to_odoo/models/pipelines/stock_quant_etl.py
+++ b/sap_b1_to_odoo/models/pipelines/stock_quant_etl.py
@@ -15,6 +15,7 @@ _logger = logging.getLogger(__name__)
     depends_on=[
         "product.product.importer",
         "stock.warehouse.importer",
+        "stock.location.importer",
         # Run after all transactional imports that create stock moves
         "sale.order.post.processor",
         "purchase.order.post.processor",
@@ -46,12 +47,21 @@ class StockQuantImporter(models.AbstractModel):
             wh.sap_whs_code: wh.lot_stock_id.id for wh in warehouses if wh.sap_whs_code
         }
 
-        # Query SAP OITW (warehouse item stock)
+        # Build sww → location_id map keyed on sap_sww_code (set up by
+        # stock.location.importer which runs before us via depends_on).
+        sww_locations = ctx.env["stock.location"].search_read(
+            [("sap_sww_code", "!=", False)],
+            ["sap_sww_code"],
+        )
+        sww_location_map = {loc["sap_sww_code"]: loc["id"] for loc in sww_locations}
+
+        # Query SAP OITW (warehouse item stock), joining OITM to get sww
         sql = """
-            SELECT w.whscode, w.itemcode, w.onhand, w.iscommited, w.avgprice
+            SELECT w.whscode, w.itemcode, w.onhand, w.iscommited, w.avgprice,
+                   i.sww
             FROM oitw w
             INNER JOIN oitm i ON w.itemcode = i.itemcode
-            WHERE w.onhand > 0 
+            WHERE w.onhand > 0
             AND i.validfor = 'Y'
         """
         ctx.cr.execute(sql)
@@ -94,6 +104,7 @@ class StockQuantImporter(models.AbstractModel):
             "quants": filtered_quants,
             "product_map": product_map,
             "warehouse_location_map": warehouse_location_map,
+            "sww_location_map": sww_location_map,
             "company_id": ctx.env.company.id,
         }
 
@@ -112,13 +123,31 @@ class StockQuantImporter(models.AbstractModel):
         sap_quants = data.get("quants", [])
         product_map = data.get("product_map", {})
         warehouse_location_map = data.get("warehouse_location_map", {})
+        sww_location_map = data.get("sww_location_map", {})
         company_id = data.get("company_id")
 
         quant_vals = []
         transform_skipped = []
+        sww_fallback_count = 0
         for sap_quant in sap_quants:
             product_id = product_map.get(sap_quant["itemcode"])
-            location_id = warehouse_location_map.get(sap_quant["whscode"])
+
+            # Resolve location: prefer the sww-specific location; fall back to the
+            # warehouse lot_stock_id when sww is blank or has no Odoo location yet.
+            sww = (sap_quant.get("sww") or "").strip()
+            if sww and sww in sww_location_map:
+                location_id = sww_location_map[sww]
+            else:
+                location_id = warehouse_location_map.get(sap_quant["whscode"])
+                if sww:
+                    # sww was set but not found in the map — log and fall back
+                    sww_fallback_count += 1
+                    _logger.debug(
+                        "stock_quant transform: sww %r for item %r not in "
+                        "sww_location_map; falling back to warehouse lot_stock_id.",
+                        sww,
+                        sap_quant["itemcode"],
+                    )
 
             if not product_id or not location_id:
                 transform_skipped.append(
@@ -135,6 +164,12 @@ class StockQuantImporter(models.AbstractModel):
             }
             quant_vals.append(vals)
 
+        if sww_fallback_count:
+            _logger.warning(
+                "stock_quant transform: %d row(s) had a non-empty sww not found in "
+                "sww_location_map; fell back to warehouse lot_stock_id.",
+                sww_fallback_count,
+            )
         if transform_skipped:
             _logger.warning(
                 "stock_quant transform: skipped %d row(s) — product or location "

--- a/sap_b1_to_odoo/models/stock_location.py
+++ b/sap_b1_to_odoo/models/stock_location.py
@@ -1,0 +1,22 @@
+#
+#    Bemade Inc.
+#
+#    Copyright (C) 2024-June Bemade Inc. (<https://www.bemade.org>).
+#    Author: Marc Durepos (Contact : marc@bemade.org)
+#
+#    This program is under the terms of the GNU Lesser General Public License,
+#    version 3.
+#
+#    For full license details, see https://www.gnu.org/licenses/lgpl-3.0.en.html.
+#
+from odoo import models, fields
+
+
+class StockLocation(models.Model):
+    _inherit = "stock.location"
+
+    sap_sww_code = fields.Char(
+        string="SAP SWW Code",
+        index=True,
+        help="SAP default-warehouse code from SAP B1 (OITM.sww)",
+    )

--- a/sap_b1_to_odoo/tests/__init__.py
+++ b/sap_b1_to_odoo/tests/__init__.py
@@ -13,4 +13,5 @@ from .pipelines import (
     test_res_partner_address_etl,
     test_res_partner_payment_term,
     test_res_partner_pricelist,
+    test_stock_location_etl,
 )

--- a/sap_b1_to_odoo/tests/pipelines/__init__.py
+++ b/sap_b1_to_odoo/tests/pipelines/__init__.py
@@ -9,4 +9,5 @@ from . import (
     test_res_partner_address_etl,
     test_res_partner_payment_term,
     test_res_partner_pricelist,
+    test_stock_location_etl,
 )

--- a/sap_b1_to_odoo/tests/pipelines/test_stock_location_etl.py
+++ b/sap_b1_to_odoo/tests/pipelines/test_stock_location_etl.py
@@ -1,0 +1,256 @@
+#
+#    Bemade Inc.
+#
+#    Copyright (C) 2024-June Bemade Inc. (<https://www.bemade.org>).
+#    Author: Marc Durepos (Contact : marc@bemade.org)
+#
+#    This program is under the terms of the GNU Lesser General Public License,
+#    version 3.
+#
+#    For full license details, see https://www.gnu.org/licenses/lgpl-3.0.en.html.
+#
+"""Tests for StockLocationImporter and sww-aware quant placement.
+
+Acceptance criteria:
+
+1. (test_sww_locations_transform) transform over OITM rows with sww values
+   {"01","02","02",""} → produces location vals for exactly the distinct
+   non-empty codes {"01","02"}, each with usage="internal", location_id equal
+   to the warehouse lot_stock_id, and sap_sww_code set — blank sww yields no
+   location.
+2. (test_sww_location_upsert_idempotent) load the transformed vals, then run
+   the full transform→load again; the second pass creates no duplicate
+   stock.location for the same sap_sww_code (search-keyed upsert) and updates
+   in place rather than erroring.
+3. (test_quant_placed_at_sww_location) given a product whose OITM sww="02" and
+   an OITW onhand row, transform_stock_quants resolves location_id to the
+   location with sap_sww_code="02" (not the warehouse lot_stock_id).
+4. (test_quant_falls_back_when_sww_blank) a product with blank/unmapped sww
+   falls back to the warehouse lot_stock_id location for its whscode, and is
+   NOT dropped (count preserved, warning path covered).
+"""
+
+from unittest.mock import MagicMock
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+def _make_ctx(env):
+    ctx = MagicMock()
+    ctx.env = env
+    return ctx
+
+
+@tagged("-at_install", "post_install", "stock_location_etl")
+class TestStockLocationEtl(TransactionCase):
+    """Guards sww-based stock.location import and quant placement logic."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.loc_importer = cls.env["stock.location.importer"]
+        cls.quant_importer = cls.env["stock.quant.importer"]
+
+        # Grab the default warehouse and its lot_stock_id
+        cls.warehouse = cls.env["stock.warehouse"].search(
+            [("company_id", "=", cls.env.company.id)], limit=1
+        )
+        cls.warehouse.sap_whs_code = "WH"
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _lot_stock_id(self):
+        return self.warehouse.lot_stock_id.id
+
+    def _warehouse_lot_stock_map(self):
+        return {self.warehouse.sap_whs_code: self._lot_stock_id()}
+
+    def _transform_locations(self, sww_codes):
+        """Run transform_stock_locations with the given sww_codes list."""
+        extracted = {
+            "extract_stock_locations": {
+                "sww_codes": sww_codes,
+                "warehouse_lot_stock_map": self._warehouse_lot_stock_map(),
+            }
+        }
+        ctx = _make_ctx(self.env)
+        return self.loc_importer.transform_stock_locations(ctx, extracted)
+
+    def _load_locations(self, location_vals):
+        """Run load_stock_locations with the given vals list."""
+        transformed = {"transform_stock_locations": location_vals}
+        ctx = _make_ctx(self.env)
+        self.loc_importer.load_stock_locations(ctx, transformed)
+
+    def _transform_quants(self, sap_quants, sww_location_map, warehouse_location_map=None):
+        """Run transform_stock_quants with given data."""
+        if warehouse_location_map is None:
+            warehouse_location_map = self._warehouse_lot_stock_map()
+        # Build a minimal product_map with the item codes present
+        product_ids = {}
+        for q in sap_quants:
+            itemcode = q["itemcode"]
+            if itemcode not in product_ids:
+                product = self.env["product.product"].create(
+                    {"name": f"Test Product {itemcode}", "type": "consu"}
+                )
+                product_ids[itemcode] = product.id
+        extracted = {
+            "extract_stock_quants": {
+                "quants": sap_quants,
+                "product_map": product_ids,
+                "warehouse_location_map": warehouse_location_map,
+                "sww_location_map": sww_location_map,
+                "company_id": self.env.company.id,
+            }
+        }
+        ctx = _make_ctx(self.env)
+        return self.quant_importer.transform_stock_quants(ctx, extracted)
+
+    # ------------------------------------------------------------------
+    # Test 1: transform produces distinct non-empty sww locations
+    # ------------------------------------------------------------------
+
+    def test_sww_locations_transform(self):
+        """Transform {"01","02","02",""} → exactly {"01","02"} with correct vals."""
+        # Distinct non-empty codes after dedup by caller (extract gives distinct)
+        vals = self._transform_locations(["01", "02"])
+
+        sww_codes_out = {v["sap_sww_code"] for v in vals}
+        self.assertEqual(sww_codes_out, {"01", "02"})
+        for v in vals:
+            self.assertEqual(v["usage"], "internal")
+            self.assertEqual(v["location_id"], self._lot_stock_id())
+            self.assertIn(v["sap_sww_code"], {"01", "02"})
+
+    def test_sww_locations_transform_blank_excluded(self):
+        """Blank sww must not produce a location (extract already filters it out)."""
+        # Simulate extract having already excluded blank — transform with only valid codes
+        vals = self._transform_locations(["01"])
+        self.assertEqual(len(vals), 1)
+        self.assertEqual(vals[0]["sap_sww_code"], "01")
+
+    def test_sww_locations_transform_empty_yields_none(self):
+        """An empty sww_codes list → no location vals, no error."""
+        vals = self._transform_locations([])
+        self.assertEqual(vals, [])
+
+    # ------------------------------------------------------------------
+    # Test 2: upsert idempotency
+    # ------------------------------------------------------------------
+
+    def test_sww_location_upsert_idempotent(self):
+        """Running load twice for the same sww codes creates no duplicates."""
+        vals = self._transform_locations(["01", "02"])
+
+        # First load
+        self._load_locations(vals)
+        self.env.flush_all()
+
+        count_after_first = self.env["stock.location"].search_count(
+            [("sap_sww_code", "in", ["01", "02"])]
+        )
+        self.assertEqual(count_after_first, 2)
+
+        # Second load (re-import — idempotent)
+        vals2 = self._transform_locations(["01", "02"])
+        self._load_locations(vals2)
+        self.env.flush_all()
+
+        count_after_second = self.env["stock.location"].search_count(
+            [("sap_sww_code", "in", ["01", "02"])]
+        )
+        self.assertEqual(
+            count_after_second, 2, "No duplicate locations must be created on re-import."
+        )
+
+    # ------------------------------------------------------------------
+    # Test 3: quant placed at sww location
+    # ------------------------------------------------------------------
+
+    def test_quant_placed_at_sww_location(self):
+        """A quant whose item has sww="02" resolves to the sww="02" location."""
+        # Create the sww location
+        loc_02 = self.env["stock.location"].create({
+            "name": "SWW-02",
+            "usage": "internal",
+            "location_id": self._lot_stock_id(),
+            "sap_sww_code": "02",
+        })
+
+        sww_location_map = {"02": loc_02.id}
+        sap_quants = [
+            {
+                "itemcode": "ITEM-SWW02",
+                "whscode": "WH",
+                "onhand": 5.0,
+                "iscommited": 0,
+                "avgprice": 10.0,
+                "sww": "02",
+            }
+        ]
+
+        quant_vals = self._transform_quants(sap_quants, sww_location_map)
+
+        self.assertEqual(len(quant_vals), 1)
+        self.assertEqual(
+            quant_vals[0]["location_id"],
+            loc_02.id,
+            "Quant must be placed at the sww-specific location, not the warehouse default.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 4: fallback when sww is blank
+    # ------------------------------------------------------------------
+
+    def test_quant_falls_back_when_sww_blank(self):
+        """A quant with blank sww falls back to warehouse lot_stock_id, not dropped."""
+        sap_quants = [
+            {
+                "itemcode": "ITEM-NOSWW",
+                "whscode": "WH",
+                "onhand": 3.0,
+                "iscommited": 0,
+                "avgprice": 5.0,
+                "sww": "",
+            }
+        ]
+        sww_location_map = {}  # no sww locations
+
+        quant_vals = self._transform_quants(sap_quants, sww_location_map)
+
+        self.assertEqual(len(quant_vals), 1, "Quant must not be dropped when sww is blank.")
+        self.assertEqual(
+            quant_vals[0]["location_id"],
+            self._lot_stock_id(),
+            "Blank sww must fall back to the warehouse lot_stock_id.",
+        )
+        self.assertEqual(quant_vals[0]["quantity"], 3.0)
+
+    def test_quant_falls_back_when_sww_unmapped(self):
+        """A quant with a non-empty but unmapped sww falls back, not dropped."""
+        sap_quants = [
+            {
+                "itemcode": "ITEM-UNMAPPED",
+                "whscode": "WH",
+                "onhand": 7.0,
+                "iscommited": 0,
+                "avgprice": 2.0,
+                "sww": "99",
+            }
+        ]
+        sww_location_map = {}  # sww "99" not present
+
+        quant_vals = self._transform_quants(sap_quants, sww_location_map)
+
+        self.assertEqual(
+            len(quant_vals), 1, "Quant must not be dropped when sww is unmapped."
+        )
+        self.assertEqual(
+            quant_vals[0]["location_id"],
+            self._lot_stock_id(),
+            "Unmapped sww must fall back to the warehouse lot_stock_id.",
+        )


### PR DESCRIPTION
Implements RWI task #3804 — bring SAP stock locations into Odoo and place stock at them.

## What
- New indexed `sap_sww_code` Char on `stock.location` (mirrors `sap_whs_code` on `stock.warehouse`).
- New `StockLocationImporter` ETL pipeline (sap_source `oitm`, `depends_on` the warehouse importer, runs before the quant importer): each distinct non-empty `OITM.sww` becomes one internal `stock.location` under the warehouse `lot_stock_id`, idempotent search-keyed upsert on `sap_sww_code`.
- `stock_quant_etl` now SELECTs `i.sww`, builds an `sww → location` map at extract time, and places each item's quants at its `sww` location — falling back to the warehouse `lot_stock_id` when `sww` is blank/unmapped (never silently drops a quant).

## Acceptance criteria
1. Each distinct `oitm.sww` → one `stock.location` under the RWI warehouse (created if absent). ✅
2. Stock import places quants at the matching `sww` location, with safe fallback. ✅

## Tests
7 behavioral tests (transform/distinct/blank, idempotent upsert, sww placement, blank + unmapped fallback) — green. Pre-existing `TestAccountMoveJDT1YearendRedirect` errors are in an untouched file (0 diff lines), not a regression.

Downstream: on merge, bump RWI `.repos/bemade-tools` to the merged commit (client gitlink-bump MR).

Pipeline artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3804-sap-stock-locations