### PR TITLE
[3817] qbo_to_odoo: persist Clearing(1005) bank suspense on import

### DIFF
--- a/qbo_to_odoo/models/pipelines/bank_journal_etl.py
+++ b/qbo_to_odoo/models/pipelines/bank_journal_etl.py
@@ -141,6 +141,131 @@ class QboBankJournalProcessor(models.AbstractModel):
 
         self._archive_deleted_journals(ctx)
 
+        # Point the company default, the active bank journals, and their
+        # in/out payment method lines at the Clearing (1005) suspense account.
+        # Runs unconditionally (even when 0 journals were created this pass) so
+        # an orchestrated import always converges on the correct suspense config.
+        self._configure_suspense_accounts(ctx)
+
+    def _ensure_clearing_suspense_account(self, ctx: ETLContext):
+        """Resolve (or create) the Clearing ``account.account`` used as suspense.
+
+        Resolution order, scoped to the current company (account.account is
+        multi-company via the ``company_ids`` M2M in 19.0):
+
+        1. code == "1005";
+        2. else name ilike "Clearing" AND account_type == "asset_current";
+        3. else create a new {code 1005, name "Clearing", asset_current,
+           reconcile} account.
+
+        We deliberately NEVER select or create the "Bank Suspense" account
+        (account 343 / "111312 Bank Suspense Account"): the directive is to use
+        Clearing (1005) for suspense everywhere, and no id is hardcoded.
+        """
+        company = ctx.env.company
+        Account = ctx.env["account.account"].with_context(active_test=False)
+
+        account = Account.search(
+            [("code", "=", "1005"), ("company_ids", "in", [company.id])],
+            limit=1,
+        )
+        if not account:
+            account = Account.search(
+                [
+                    ("name", "ilike", "Clearing"),
+                    ("account_type", "=", "asset_current"),
+                    ("company_ids", "in", [company.id]),
+                ],
+                limit=1,
+            )
+        if not account:
+            account = Account.create(
+                {
+                    "name": "Clearing",
+                    "code": "1005",
+                    "account_type": "asset_current",
+                    "reconcile": True,
+                    "company_ids": [(6, 0, [company.id])],
+                }
+            )
+            _logger.info(
+                "Created Clearing suspense account %s for company %s",
+                account.code,
+                company.name,
+            )
+        return account
+
+    def _configure_suspense_accounts(self, ctx: ETLContext) -> None:
+        """Wire the Clearing (1005) account in as the suspense account.
+
+        Sets it as (a) the company default so future journals auto-inherit it
+        (``account.journal.suspense_account_id`` is a stored computed that falls
+        back to ``company.account_journal_suspense_account_id``), (b) the
+        suspense account on every active, non-"(deleted)" bank journal, and
+        (c) the ``payment_account_id`` on those journals' inbound/outbound
+        payment method lines.
+
+        The method line write is a blanket OVERWRITE (not a fill-if-empty):
+        QBO migrations leave some lines pointing at the wrong account
+        ("111312 Bank Suspense Account" / acct 343); the directive is "1005
+        everywhere", so every in/out line is repointed regardless of its
+        current value. Idempotent: every step searches and sets to a fixed
+        target, so re-runs are no-ops.
+        """
+        clearing = self._ensure_clearing_suspense_account(ctx)
+        if not clearing:
+            _logger.warning(
+                "Could not resolve a Clearing suspense account; "
+                "skipping suspense configuration."
+            )
+            return
+
+        company = ctx.env.company
+
+        # Company-level default: set only if it differs, so future bank
+        # journals inherit Clearing without an unnecessary write.
+        if company.account_journal_suspense_account_id != clearing:
+            company.account_journal_suspense_account_id = clearing
+            _logger.info(
+                "Set company %s default suspense account to %s",
+                company.name,
+                clearing.code,
+            )
+
+        # Active bank journals, excluding QBO "(deleted)"-named carryovers.
+        journals = ctx.env["account.journal"].search(
+            [
+                ("company_id", "=", company.id),
+                ("type", "=", "bank"),
+                ("name", "not ilike", "(deleted)"),
+            ]
+        )
+        if journals:
+            journals.write({"suspense_account_id": clearing.id})
+            _logger.info(
+                "Set suspense_account_id to %s on %d bank journal(s)",
+                clearing.code,
+                len(journals),
+            )
+
+        # Their inbound/outbound payment method lines: overwrite all
+        # (including any bad 343 references) so payments route through Clearing.
+        lines = ctx.env["account.payment.method.line"].search(
+            [
+                ("journal_id", "in", journals.ids),
+                ("payment_type", "in", ("inbound", "outbound")),
+            ]
+        )
+        if lines:
+            lines.write({"payment_account_id": clearing.id})
+            _logger.info(
+                "Set payment_account_id to %s on %d in/out payment method "
+                "line(s) across %d journal(s)",
+                clearing.code,
+                len(lines),
+                len(lines.mapped("journal_id")),
+            )
+
     @staticmethod
     def _archive_deleted_journals(ctx: ETLContext) -> None:
         """Archive every active ``account.journal`` whose name contains "deleted".

--- a/qbo_to_odoo/tests/__init__.py
+++ b/qbo_to_odoo/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_skip_cogs_generation
 from . import test_archive_deleted_journals
 from . import test_product_name_sales_description
 from . import test_product_name_locale
+from . import test_bank_journal_suspense

--- a/qbo_to_odoo/tests/test_bank_journal_suspense.py
+++ b/qbo_to_odoo/tests/test_bank_journal_suspense.py
@@ -1,0 +1,277 @@
+"""Tests for the Clearing (1005) suspense-account configuration step.
+
+Acceptance criteria (task 3817):
+1. The Clearing account is RESOLVED, not blindly created: an existing 1005
+   (or a "Clearing" asset_current) is reused; the "Bank Suspense" account
+   (343 / "111312 Bank Suspense Account") is NEVER selected or created. When
+   no Clearing account exists at all, one is created (code 1005, asset_current,
+   reconcile).
+2. The Clearing account is set as the company default suspense account and as
+   suspense_account_id on every active, non-"(deleted)" bank journal. Non-bank
+   journals and "(deleted)"-named journals are left untouched.
+3. The inbound/outbound payment.method.lines of those bank journals are
+   repointed to Clearing — including a blanket OVERWRITE of lines that were
+   pointing at the bad 343 account. "(deleted)"-journal lines are untouched.
+4. "(deleted)"-named bank journals are excluded by name from all of the above.
+
+Plus: idempotency (run twice -> still one 1005 account, values stable) and a
+343 -> 1005 overwrite regression.
+
+The configuration step is invoked directly with a minimal ETLContext (no live
+QBO feed), exactly as the sibling pipeline tests do.
+"""
+
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.etl_framework import ETLContext
+
+
+def _make_ctx(env):
+    """Build a minimal ETLContext backed by the Odoo test env."""
+    return ETLContext(cr=None, env=env)
+
+
+@tagged("post_install", "-at_install", "qbo_bank_suspense")
+class TestBankJournalSuspense(TransactionCase):
+    """Unit tests for QboBankJournalProcessor suspense configuration."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.processor = cls.env["qbo.bank.journal.processor"]
+        cls.company = cls.env.company
+
+        Account = cls.env["account.account"]
+        Journal = cls.env["account.journal"]
+        PMLine = cls.env["account.payment.method.line"]
+
+        # BAD account: the "Bank Suspense" account the migration mistakenly used.
+        cls.bad_account = Account.create({
+            "name": "111312 Bank Suspense Account",
+            "code": "343BAD",
+            "account_type": "asset_current",
+            "company_ids": [(6, 0, [cls.company.id])],
+        })
+
+        # GOOD account: Clearing (1005) — what suspense should resolve to.
+        cls.good_account = Account.create({
+            "name": "Clearing",
+            "code": "1005",
+            "account_type": "asset_current",
+            "reconcile": True,
+            "company_ids": [(6, 0, [cls.company.id])],
+        })
+
+        # Two active bank journals, one "(deleted)" bank journal, one non-bank.
+        cls.bank_a = Journal.create({
+            "name": "Operating Bank A",
+            "type": "bank",
+            "code": "SUSPA",
+            "company_id": cls.company.id,
+        })
+        cls.bank_b = Journal.create({
+            "name": "Operating Bank B",
+            "type": "bank",
+            "code": "SUSPB",
+            "company_id": cls.company.id,
+        })
+        cls.bank_deleted = Journal.create({
+            "name": "Legacy Bank (deleted)",
+            "type": "bank",
+            "code": "SUSPD",
+            "company_id": cls.company.id,
+        })
+        cls.cash_journal = Journal.create({
+            "name": "Petty Cash",
+            "type": "cash",
+            "code": "SUSPC",
+            "company_id": cls.company.id,
+        })
+
+        # Pre-point some in/out method lines at the BAD account to exercise the
+        # overwrite path. Bank journals auto-create inbound/outbound manual
+        # method lines on creation; grab and corrupt them.
+        cls.bank_a_lines = PMLine.search([
+            ("journal_id", "=", cls.bank_a.id),
+            ("payment_type", "in", ("inbound", "outbound")),
+        ])
+        cls.bank_b_lines = PMLine.search([
+            ("journal_id", "=", cls.bank_b.id),
+            ("payment_type", "in", ("inbound", "outbound")),
+        ])
+        cls.deleted_lines = PMLine.search([
+            ("journal_id", "=", cls.bank_deleted.id),
+            ("payment_type", "in", ("inbound", "outbound")),
+        ])
+
+        # Corrupt bank_a's lines: point them at the bad 343-style account.
+        if cls.bank_a_lines:
+            cls.bank_a_lines.write({"payment_account_id": cls.bad_account.id})
+        # Corrupt the deleted journal's lines too, to prove they stay untouched.
+        if cls.deleted_lines:
+            cls.deleted_lines.write({"payment_account_id": cls.bad_account.id})
+
+    # ---- AC1: resolve-not-create, never 343 ---------------------------------
+
+    def test_ac1_resolves_existing_clearing_not_343(self):
+        """AC1: existing 1005 is reused; bad 343 account is never chosen."""
+        ctx = _make_ctx(self.env)
+        resolved = self.processor._ensure_clearing_suspense_account(ctx)
+
+        self.assertEqual(
+            resolved, self.good_account,
+            "must resolve to the existing Clearing (1005) account",
+        )
+        self.assertNotEqual(
+            resolved, self.bad_account,
+            "must NEVER resolve to the 111312 Bank Suspense account",
+        )
+
+    def test_ac1_creates_clearing_when_absent(self):
+        """AC1: when no Clearing/1005 exists, a new one is created (not 343)."""
+        ctx = _make_ctx(self.env)
+        Account = self.env["account.account"].with_context(active_test=False)
+
+        # Rename the good account out of the way so nothing matches.
+        self.good_account.write({"code": "1005X", "name": "Renamed"})
+
+        before = Account.search_count([
+            ("code", "=", "1005"),
+            ("company_ids", "in", [self.company.id]),
+        ])
+        self.assertEqual(before, 0, "precondition: no 1005 account present")
+
+        resolved = self.processor._ensure_clearing_suspense_account(ctx)
+
+        self.assertEqual(resolved.code, "1005")
+        self.assertEqual(resolved.account_type, "asset_current")
+        self.assertTrue(resolved.reconcile)
+        self.assertNotEqual(
+            resolved, self.bad_account,
+            "must not adopt the 111312 Bank Suspense account",
+        )
+        self.assertIn(self.company.id, resolved.company_ids.ids)
+        # No restore needed: TransactionCase rolls back to the class savepoint
+        # after each test method, so the renamed good_account is reverted.
+
+    # ---- AC2: company default + bank journal suspense ------------------------
+
+    def test_ac2_company_default_and_bank_journals_set(self):
+        """AC2: company default + active bank journals set; cash/deleted untouched."""
+        ctx = _make_ctx(self.env)
+
+        self.processor._configure_suspense_accounts(ctx)
+
+        for rec in (self.company, self.bank_a, self.bank_b,
+                    self.bank_deleted, self.cash_journal):
+            rec.invalidate_recordset()
+
+        self.assertEqual(
+            self.company.account_journal_suspense_account_id, self.good_account,
+            "company default suspense account must be Clearing (1005)",
+        )
+        self.assertEqual(
+            self.bank_a.suspense_account_id, self.good_account,
+            "active bank journal A must point at Clearing",
+        )
+        self.assertEqual(
+            self.bank_b.suspense_account_id, self.good_account,
+            "active bank journal B must point at Clearing",
+        )
+        self.assertNotEqual(
+            self.bank_deleted.suspense_account_id, self.good_account,
+            "'(deleted)' bank journal must NOT be touched",
+        )
+
+    # ---- AC3: in/out method lines repointed, incl. 343 overwrite -----------
+
+    def test_ac3_method_lines_repointed_overwriting_343(self):
+        """AC3: in/out lines (incl. those on 343) go to 1005; deleted untouched."""
+        ctx = _make_ctx(self.env)
+
+        # Sanity: bank_a lines start on the bad account.
+        if self.bank_a_lines:
+            self.assertTrue(
+                all(l.payment_account_id == self.bad_account
+                    for l in self.bank_a_lines),
+                "precondition: bank_a in/out lines point at the bad 343 account",
+            )
+
+        self.processor._configure_suspense_accounts(ctx)
+
+        for line in (self.bank_a_lines | self.bank_b_lines
+                     | self.deleted_lines):
+            line.invalidate_recordset()
+
+        for line in self.bank_a_lines:
+            self.assertEqual(
+                line.payment_account_id, self.good_account,
+                "bad-343 in/out line must be OVERWRITTEN to Clearing",
+            )
+        for line in self.bank_b_lines:
+            self.assertEqual(
+                line.payment_account_id, self.good_account,
+                "empty/other in/out line must be set to Clearing",
+            )
+        for line in self.deleted_lines:
+            self.assertNotEqual(
+                line.payment_account_id, self.good_account,
+                "'(deleted)' journal's in/out lines must NOT be touched",
+            )
+
+    # ---- AC4: "(deleted)" exclusion -----------------------------------------
+
+    def test_ac4_deleted_named_journals_excluded(self):
+        """AC4: a "(deleted)" bank journal is excluded from suspense config."""
+        ctx = _make_ctx(self.env)
+
+        self.processor._configure_suspense_accounts(ctx)
+        self.bank_deleted.invalidate_recordset()
+
+        self.assertNotEqual(
+            self.bank_deleted.suspense_account_id, self.good_account,
+            "the '(deleted)' journal must be excluded by name",
+        )
+
+    # ---- Idempotency --------------------------------------------------------
+
+    def test_idempotent_on_rerun(self):
+        """Running twice keeps a single 1005 account and stable values."""
+        ctx = _make_ctx(self.env)
+        Account = self.env["account.account"].with_context(active_test=False)
+
+        self.processor._configure_suspense_accounts(ctx)
+        self.processor._configure_suspense_accounts(ctx)
+
+        count = Account.search_count([
+            ("code", "=", "1005"),
+            ("company_ids", "in", [self.company.id]),
+        ])
+        self.assertEqual(count, 1, "re-run must not create a second 1005 account")
+
+        for rec in (self.company, self.bank_a, self.bank_b):
+            rec.invalidate_recordset()
+        self.assertEqual(
+            self.company.account_journal_suspense_account_id, self.good_account)
+        self.assertEqual(self.bank_a.suspense_account_id, self.good_account)
+        self.assertEqual(self.bank_b.suspense_account_id, self.good_account)
+
+    # ---- 343 -> 1005 overwrite regression -----------------------------------
+
+    def test_343_overwrite_regression(self):
+        """Regression: NO in/out line on an active bank journal keeps 343."""
+        ctx = _make_ctx(self.env)
+
+        self.processor._configure_suspense_accounts(ctx)
+
+        PMLine = self.env["account.payment.method.line"]
+        active_bank_ids = (self.bank_a | self.bank_b).ids
+        still_bad = PMLine.search([
+            ("journal_id", "in", active_bank_ids),
+            ("payment_type", "in", ("inbound", "outbound")),
+            ("payment_account_id", "=", self.bad_account.id),
+        ])
+        self.assertFalse(
+            still_bad,
+            "no active bank journal in/out line may still point at 343",
+        )


### PR DESCRIPTION
## What this does

Persists the **Clearing (1005)** bank-suspense configuration so it is reproduced automatically on every QBO migration, instead of relying on a manual live-instance fix (task 3817, Vera).

At the end of the QBO bank-journal load (`qbo.bank.journal.processor.load_journals`), a new `_configure_suspense_accounts` step:

- **Find-or-ensures** the Clearing suspense account by **code `1005`** (current asset, reconcilable) — `active_test=False`, company-scoped. Falls back to a `name ilike "Clearing"` + `asset_current` account, else creates code 1005. It **never** selects or creates account `343` / "111312 Bank Suspense Account" (bad data) and hardcodes no DB id.
- Sets `company.account_journal_suspense_account_id = 1005` (only if differing) so journals created later auto-inherit it.
- Writes `suspense_account_id = 1005` on every **active** bank journal whose name does not contain `"(deleted)"`.
- **Overwrites** `payment_account_id = 1005` on those journals' pending inbound/outbound `account.payment.method.line` records (including any still pointing at the bad 343).

Idempotent (search-and-set to a fixed target; runs even when 0 journals are created this pass). Mirrors the existing SAP-B1 `account_journal_setup` suspense pattern.

## Tests

`qbo_to_odoo/tests/test_bank_journal_suspense.py` — 7 behavioral tests covering all four acceptance criteria + idempotency + the 343→1005 overwrite regression. **Full `qbo_to_odoo` suite green (55 tests, 0 failed/0 error)** on Odoo 19.0.

## Downstream

On merge, Vera's `.repos/bemade-tools` pointer is bumped to the merged commit via a downstream verajet MR (task 3817, project 291). Companion task #3818 (archive "(deleted)" journals) ships separately.
