### PR TITLE
feat: add version-bump enforcement (pre-commit hook + CI)

### DIFF
--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -1,0 +1,30 @@
+name: version-bump-check
+# Enforces the module-versioning convention: any module changed in a PR must
+# bump its __manifest__.py version vs the target branch.
+# See https://github.com/bemade/pre-commit-hooks and odoo-project-guide §7.
+#
+# OPT-IN / HELD: the job only runs when the repository variable
+# VERSION_BUMP_CHECK is set to "true" (Settings → Secrets and variables →
+# Actions → Variables). Held until the autonomous worker learns to bump
+# (task #3891), to avoid failing its in-flight PRs.
+
+on:
+  pull_request:
+
+jobs:
+  version-bump-check:
+    if: vars.VERSION_BUMP_CHECK == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so the merge-base for the diff exists
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install the check
+        run: pip install "bemade-pre-commit-hooks @ git+https://github.com/bemade/pre-commit-hooks@v0.1.0"
+      - name: Check manifest version bumps
+        run: |
+          git fetch --quiet origin "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+          bemade-check-version-bump --against "origin/${GITHUB_BASE_REF}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# Bemade shared hooks — enforce a manifest version bump on every module change.
+# See https://github.com/bemade/pre-commit-hooks and the odoo-project-guide §7.
+repos:
+  - repo: https://github.com/bemade/pre-commit-hooks
+    rev: v0.1.0
+    hooks:
+      - id: check-manifest-version-bump


### PR DESCRIPTION
Adds version-bump enforcement to this repo:

1. **`.pre-commit-config.yaml`** — references [bemade/pre-commit-hooks](https://github.com/bemade/pre-commit-hooks) v0.1.0 (`check-manifest-version-bump`). Run `pre-commit install` locally to block commits that change a module without bumping its `__manifest__.py` version.
2. **`.github/workflows/version-bump-check.yml`** — CI backstop running `bemade-check-version-bump --against origin/<base>` (diff-aware; the GitHub analog of the shared odoo-ci `version_bump_check` job).

Rule + rationale: odoo-project-guide §7. **Held / opt-in:** the CI job only runs when the repo variable `VERSION_BUMP_CHECK=true` is set — kept dormant until the autonomous worker learns to bump (task #3891), so it won't fail in-flight worker PRs.

NB: our hook is diff-based and is intentionally **not** part of any `pre-commit run --all-files` job (it'd flag every module); it runs only as this dedicated `--against` step. The broader OCA pre-commit suite in CI is a separate follow-up.