### PR TITLE
chore: bump bemade pre-commit-hooks to v0.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,6 @@
 # See https://github.com/bemade/pre-commit-hooks and the odoo-project-guide §7.
 repos:
   - repo: https://github.com/bemade/pre-commit-hooks
-    rev: v0.1.0
+    rev: v0.1.1
     hooks:
       - id: check-manifest-version-bump


### PR DESCRIPTION
Bumps `check-manifest-version-bump` to v0.1.1 (safe under `pre-commit run --all-files`). Auto-merge on green CI.