### PR TITLE
fix(stock_quant_etl): scope sww bin to item's home warehouse row

### DIFF
--- a/sap_b1_to_odoo/__manifest__.py
+++ b/sap_b1_to_odoo/__manifest__.py
@@ -20,7 +20,7 @@
 {
     "name": "SAP Business One to Odoo",
 
-    "version": "19.0.0.1.3",
+    "version": "19.0.0.1.4",
     "summary": "Convert a database from SAP Business One to Odoo",
     "category": "Technical",
     "author": "Bemade Inc.",

--- a/sap_b1_to_odoo/__manifest__.py
+++ b/sap_b1_to_odoo/__manifest__.py
@@ -20,7 +20,7 @@
 {
     "name": "SAP Business One to Odoo",
 
-    "version": "19.0.0.1.2",
+    "version": "19.0.0.1.3",
     "summary": "Convert a database from SAP Business One to Odoo",
     "category": "Technical",
     "author": "Bemade Inc.",

--- a/sap_b1_to_odoo/models/pipelines/stock_quant_etl.py
+++ b/sap_b1_to_odoo/models/pipelines/stock_quant_etl.py
@@ -55,10 +55,12 @@ class StockQuantImporter(models.AbstractModel):
         )
         sww_location_map = {loc["sap_sww_code"]: loc["id"] for loc in sww_locations}
 
-        # Query SAP OITW (warehouse item stock), joining OITM to get sww
+        # Query SAP OITW (warehouse item stock), joining OITM to get sww and
+        # dfltwh (the item's home warehouse — used to scope the sww bin to
+        # the home-warehouse row only; see transform_stock_quants).
         sql = """
             SELECT w.whscode, w.itemcode, w.onhand, w.iscommited, w.avgprice,
-                   i.sww
+                   i.sww, i.dfltwh
             FROM oitw w
             INNER JOIN oitm i ON w.itemcode = i.itemcode
             WHERE w.onhand > 0
@@ -130,15 +132,25 @@ class StockQuantImporter(models.AbstractModel):
         for sap_quant in sap_quants:
             product_id = product_map.get(sap_quant["itemcode"])
 
-            # Resolve location: prefer the sww-specific location; fall back to the
-            # warehouse lot_stock_id when sww is blank or has no Odoo location yet.
+            # Resolve location: prefer the sww-specific location, but ONLY for
+            # the row whose whscode is the item's home warehouse (dfltwh) —
+            # an item's sww bin is a single physical bin, so it can only ever
+            # hold the onhand for its home warehouse. Every other warehouse
+            # row for the same item falls back to its own warehouse
+            # lot_stock_id, exactly like blank-sww items, so multi-warehouse
+            # onhand is never collapsed onto one (product_id, location_id).
             sww = (sap_quant.get("sww") or "").strip()
-            if sww and sww in sww_location_map:
+            whscode = (sap_quant.get("whscode") or "").strip()
+            dfltwh = (sap_quant.get("dfltwh") or "").strip()
+            is_home_warehouse_row = whscode == dfltwh
+
+            if sww and is_home_warehouse_row and sww in sww_location_map:
                 location_id = sww_location_map[sww]
             else:
                 location_id = warehouse_location_map.get(sap_quant["whscode"])
-                if sww:
-                    # sww was set but not found in the map — log and fall back
+                if sww and is_home_warehouse_row:
+                    # sww was set on the home-warehouse row but not found in
+                    # the map — log and fall back.
                     sww_fallback_count += 1
                     _logger.debug(
                         "stock_quant transform: sww %r for item %r not in "

--- a/sap_b1_to_odoo/tests/pipelines/test_stock_location_etl.py
+++ b/sap_b1_to_odoo/tests/pipelines/test_stock_location_etl.py
@@ -28,6 +28,12 @@ Acceptance criteria:
 4. (test_quant_falls_back_when_sww_blank) a product with blank/unmapped sww
    falls back to the warehouse lot_stock_id location for its whscode, and is
    NOT dropped (count preserved, warning path covered).
+5. (test_quant_multiwarehouse_sww_splits_by_home_warehouse) an item with a
+   non-blank sww and onhand in ≥2 SAP warehouses places the sww bin ONLY on
+   the row whose whscode matches the item's dfltwh (home warehouse); every
+   other warehouse row routes to its own warehouse lot_stock_id, exactly like
+   blank-sww routing — no (product_id, location_id) collision, no dropped
+   onhand.
 """
 
 from unittest.mock import MagicMock
@@ -190,6 +196,7 @@ class TestStockLocationEtl(TransactionCase):
                 "iscommited": 0,
                 "avgprice": 10.0,
                 "sww": "02",
+                "dfltwh": "WH",
             }
         ]
 
@@ -216,6 +223,7 @@ class TestStockLocationEtl(TransactionCase):
                 "iscommited": 0,
                 "avgprice": 5.0,
                 "sww": "",
+                "dfltwh": "WH",
             }
         ]
         sww_location_map = {}  # no sww locations
@@ -240,6 +248,7 @@ class TestStockLocationEtl(TransactionCase):
                 "iscommited": 0,
                 "avgprice": 2.0,
                 "sww": "99",
+                "dfltwh": "WH",
             }
         ]
         sww_location_map = {}  # sww "99" not present
@@ -253,4 +262,196 @@ class TestStockLocationEtl(TransactionCase):
             quant_vals[0]["location_id"],
             self._lot_stock_id(),
             "Unmapped sww must fall back to the warehouse lot_stock_id.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 5: multi-warehouse items — sww applies only to the home warehouse
+    # ------------------------------------------------------------------
+
+    def _wh2_lot_stock_id(self):
+        """A second, distinct internal location standing in for a WH2 warehouse's
+        lot_stock_id — no need to create a real stock.warehouse for these tests,
+        transform_stock_quants only ever consults warehouse_location_map."""
+        if not hasattr(self, "_wh2_location"):
+            self._wh2_location = self.env["stock.location"].create({
+                "name": "WH2 Stock",
+                "usage": "internal",
+                "location_id": self.warehouse.view_location_id.id,
+            })
+        return self._wh2_location.id
+
+    def test_quant_multiwarehouse_sww_splits_by_home_warehouse(self):
+        """An item's sww bin applies ONLY to its home-warehouse (dfltwh) row;
+        the other warehouse row routes to its own warehouse lot_stock_id —
+        NOT the sww location. This is the core regression: current (buggy)
+        code places both rows at the sww location, colliding on
+        (product_id, location_id) and silently dropping one row's onhand.
+        """
+        loc_02 = self.env["stock.location"].create({
+            "name": "SWW-02-multi",
+            "usage": "internal",
+            "location_id": self._lot_stock_id(),
+            "sap_sww_code": "02",
+        })
+        sww_location_map = {"02": loc_02.id}
+        warehouse_location_map = {
+            "WH": self._lot_stock_id(),
+            "WH2": self._wh2_lot_stock_id(),
+        }
+        sap_quants = [
+            {
+                "itemcode": "ITEM-MULTI",
+                "whscode": "WH",
+                "onhand": 7.0,
+                "iscommited": 0,
+                "avgprice": 10.0,
+                "sww": "02",
+                "dfltwh": "WH",
+            },
+            {
+                "itemcode": "ITEM-MULTI",
+                "whscode": "WH2",
+                "onhand": 1.0,
+                "iscommited": 0,
+                "avgprice": 10.0,
+                "sww": "02",
+                "dfltwh": "WH",
+            },
+        ]
+
+        quant_vals = self._transform_quants(
+            sap_quants, sww_location_map, warehouse_location_map
+        )
+
+        self.assertEqual(len(quant_vals), 2, "Both warehouse rows must be preserved.")
+        by_whs = {"WH": quant_vals[0], "WH2": quant_vals[1]}
+        self.assertEqual(
+            by_whs["WH"]["location_id"],
+            loc_02.id,
+            "Home-warehouse row must be placed at the sww location.",
+        )
+        self.assertEqual(
+            by_whs["WH2"]["location_id"],
+            self._wh2_lot_stock_id(),
+            "Non-home-warehouse row must route to its own warehouse lot_stock_id, "
+            "not the sww location.",
+        )
+
+    def test_quant_multiwarehouse_no_location_collision(self):
+        """Distinct SAP warehouse rows for the same item must resolve to distinct
+        Odoo locations, and total emitted quantity must equal the sum of onhand —
+        no quant is lost to a (product_id, location_id) collision."""
+        loc_02 = self.env["stock.location"].create({
+            "name": "SWW-02-collision",
+            "usage": "internal",
+            "location_id": self._lot_stock_id(),
+            "sap_sww_code": "02",
+        })
+        sww_location_map = {"02": loc_02.id}
+        warehouse_location_map = {
+            "WH": self._lot_stock_id(),
+            "WH2": self._wh2_lot_stock_id(),
+        }
+        sap_quants = [
+            {
+                "itemcode": "ITEM-COLLISION",
+                "whscode": "WH",
+                "onhand": 7.0,
+                "iscommited": 0,
+                "avgprice": 10.0,
+                "sww": "02",
+                "dfltwh": "WH",
+            },
+            {
+                "itemcode": "ITEM-COLLISION",
+                "whscode": "WH2",
+                "onhand": 1.0,
+                "iscommited": 0,
+                "avgprice": 10.0,
+                "sww": "02",
+                "dfltwh": "WH",
+            },
+        ]
+
+        quant_vals = self._transform_quants(
+            sap_quants, sww_location_map, warehouse_location_map
+        )
+
+        self.assertEqual(len(quant_vals), 2)
+        location_ids = {v["location_id"] for v in quant_vals}
+        self.assertEqual(
+            len(location_ids), 2, "The two rows must resolve to DISTINCT locations."
+        )
+        total_quantity = sum(v["quantity"] for v in quant_vals)
+        self.assertEqual(total_quantity, 8.0, "Total quantity must equal sum of onhand.")
+
+    def test_quant_nonhome_warehouse_sww_ignored(self):
+        """An item with a non-blank sww but onhand ONLY in a non-home warehouse
+        must route to that warehouse's own location, never the sww bin —
+        mirrors blank-sww routing."""
+        loc_02 = self.env["stock.location"].create({
+            "name": "SWW-02-nonhome",
+            "usage": "internal",
+            "location_id": self._lot_stock_id(),
+            "sap_sww_code": "02",
+        })
+        sww_location_map = {"02": loc_02.id}
+        warehouse_location_map = {
+            "WH": self._lot_stock_id(),
+            "WH2": self._wh2_lot_stock_id(),
+        }
+        sap_quants = [
+            {
+                "itemcode": "ITEM-NONHOME",
+                "whscode": "WH2",
+                "onhand": 4.0,
+                "iscommited": 0,
+                "avgprice": 10.0,
+                "sww": "02",
+                "dfltwh": "WH",
+            },
+        ]
+
+        quant_vals = self._transform_quants(
+            sap_quants, sww_location_map, warehouse_location_map
+        )
+
+        self.assertEqual(len(quant_vals), 1)
+        self.assertEqual(
+            quant_vals[0]["location_id"],
+            self._wh2_lot_stock_id(),
+            "Non-home-warehouse onhand must route to its own location, never the "
+            "sww bin.",
+        )
+
+    def test_quant_home_warehouse_single_row_still_sww(self):
+        """Regression guard: an item with a single onhand row in its home
+        warehouse still lands at the sww location (existing single-warehouse
+        behavior preserved)."""
+        loc_02 = self.env["stock.location"].create({
+            "name": "SWW-02-single",
+            "usage": "internal",
+            "location_id": self._lot_stock_id(),
+            "sap_sww_code": "02",
+        })
+        sww_location_map = {"02": loc_02.id}
+        sap_quants = [
+            {
+                "itemcode": "ITEM-SINGLE-HOME",
+                "whscode": "WH",
+                "onhand": 6.0,
+                "iscommited": 0,
+                "avgprice": 10.0,
+                "sww": "02",
+                "dfltwh": "WH",
+            },
+        ]
+
+        quant_vals = self._transform_quants(sap_quants, sww_location_map)
+
+        self.assertEqual(len(quant_vals), 1)
+        self.assertEqual(
+            quant_vals[0]["location_id"],
+            loc_02.id,
+            "Single home-warehouse row must still land at the sww location.",
         )


### PR DESCRIPTION
## Bug

Multi-warehouse onhand was collapsing onto a single sww bin during the SAP
B1 -> Odoo stock quant ETL. When an item existed in more than one SAP
warehouse, the ETL was resolving the same sww bin for every warehouse row
instead of scoping it to the item's home warehouse. Because Odoo's
`stock.quant` model enforces a uniqueness constraint on
(product, location, lot, package, owner), the collapsed rows silently
overwrote each other, dropping stock for every warehouse but the last one
processed.

Originating from Odoo task #4021, project 289 ("RWI SAP B1 to Odoo
Migration").

## Fix

Scope the sww bin resolution to the item's home-warehouse `oitw` row via
`dfltwh`, and route all other warehouse rows to their own Odoo location —
matching the existing behavior already used for blank `sww`. This ensures
each SAP warehouse's onhand lands in a distinct Odoo location/quant instead
of colliding on a shared bin.

## Verification

TDD: added tests that fail against the pre-fix code and pass after the fix.
Full suite: 11/11 tests passing.

Manifest version bumped `19.0.0.1.2` -> `19.0.0.1.4` (two increments across
the fix and test commits — expected).