### PR TITLE
feat(qbo_to_odoo): year-end closing entries pipeline

### DIFF
--- a/qbo_to_odoo/__manifest__.py
+++ b/qbo_to_odoo/__manifest__.py
@@ -19,7 +19,7 @@
 #
 {
     "name": "QuickBooks Online to Odoo",
-    "version": "19.0.0.0.1",
+    "version": "19.0.0.1.0",
     "summary": "Migrate QuickBooks Online data to Odoo using ETL Framework",
     "description": """
 Migrate QuickBooks Online data to Odoo including:
@@ -59,6 +59,7 @@ Features:
     "data": [
         "security/ir.model.access.csv",
         "data/qbo_connection_setup.xml",
+        "data/ir_config_parameter.xml",
         "views/qbo_oauth_templates.xml",
         "views/qbo_connection_views.xml",
         "views/qbo_migration_report_views.xml",

--- a/qbo_to_odoo/data/ir_config_parameter.xml
+++ b/qbo_to_odoo/data/ir_config_parameter.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!--
+        Year-end closing entries (qbo.year.end.close pipeline) are opt-in:
+        every migration must explicitly enable them via this parameter
+        before any closing move is posted. noupdate="1" so a value the
+        user has already changed on-site is never overwritten by a
+        module upgrade.
+    -->
+    <record id="year_end_close_enabled" model="ir.config_parameter" forcecreate="0">
+        <field name="key">qbo_to_odoo.year_end_close.enabled</field>
+        <field name="value">0</field>
+    </record>
+
+    <record id="year_end_close_retained_earnings_code" model="ir.config_parameter" forcecreate="0">
+        <field name="key">qbo_to_odoo.year_end_close.retained_earnings_code</field>
+        <field name="value">3200</field>
+    </record>
+</odoo>

--- a/qbo_to_odoo/models/pipelines/__init__.py
+++ b/qbo_to_odoo/models/pipelines/__init__.py
@@ -25,3 +25,4 @@ from . import sales_receipt_etl
 from . import refund_receipt_etl
 from . import cc_payment_etl
 from . import journal_fallback_etl
+from . import year_end_close

--- a/qbo_to_odoo/models/pipelines/gl_helpers.py
+++ b/qbo_to_odoo/models/pipelines/gl_helpers.py
@@ -8,8 +8,13 @@ from XLSX export data.
 
 import logging
 from collections import defaultdict
+from datetime import date, timedelta
 from io import BytesIO
 from typing import Dict, List, Optional, Set, Tuple
+
+from odoo import _
+from odoo.exceptions import UserError
+from odoo.fields import Command
 
 _logger = logging.getLogger(__name__)
 
@@ -459,3 +464,286 @@ def build_cogs_completion_transactions(
             } for l in missing],
         })
     return result
+
+
+# ---------------------------------------------------------------------------
+# Year-end closing entries (qbo.year.end.close)
+# ---------------------------------------------------------------------------
+
+# ir.config_parameter keys gating and parameterizing the pass. Read at load
+# time so a migration that hasn't opted in never touches the ledger.
+YEAR_END_CLOSE_ENABLED_PARAM = "qbo_to_odoo.year_end_close.enabled"
+YEAR_END_CLOSE_RE_CODE_PARAM = "qbo_to_odoo.year_end_close.retained_earnings_code"
+DEFAULT_RETAINED_EARNINGS_CODE = "3200"
+
+# account.account.internal_group values that make up P&L (covers every
+# income_*/expense_* account_type, since internal_group is that type's
+# leading segment).
+_PNL_INTERNAL_GROUPS = ("income", "expense")
+
+# Idempotency / drift-exclusion stamp, mirroring the QBO_EXCH:/QBO_CENT_TRUEUP
+# ref conventions used elsewhere in this module.
+YEAR_END_CLOSE_REF_PREFIX = "QBO_YE_CLOSE:"
+
+
+def get_year_end_close_config(env) -> Dict:
+    """Read the year-end-close gate and destination-account config.
+
+    :return: ``{"enabled": bool, "retained_earnings_code": str}`` —
+        disabled and ``3200`` by default, so a migration that hasn't
+        opted in via ``ir.config_parameter`` never posts closing entries.
+    """
+    icp = env["ir.config_parameter"].sudo()
+    return {
+        "enabled": icp.get_param(YEAR_END_CLOSE_ENABLED_PARAM, "0") == "1",
+        "retained_earnings_code": icp.get_param(
+            YEAR_END_CLOSE_RE_CODE_PARAM, DEFAULT_RETAINED_EARNINGS_CODE
+        ),
+    }
+
+
+def get_unaffected_earnings_account(env, company):
+    """Resolve *company*'s Current-Year-Earnings account.
+
+    Searches ``active_test=False`` for ``account_type == 'equity_unaffected'``
+    scoped to *company* — deliberately NOT
+    ``company.get_unaffected_earnings_account()``, which searches active
+    accounts only and, finding none because the real one is archived
+    (322000 in this migration, archived because QBO marked it inactive and
+    ``qbo.account.finalizer`` mirrors that), would *create a duplicate
+    999999 account* (see ``account/models/company.py`` around
+    ``get_unaffected_earnings_account``).
+
+    :raises UserError: if more than one CYE account resolves — the pass
+        must never split the year-end-close allocation across two
+        accounts; a stray active duplicate has to be resolved by hand.
+    :return: the ``account.account`` recordset (empty if none found).
+    """
+    Account = env["account.account"].with_context(active_test=False)
+    accounts = Account.search([
+        *Account._check_company_domain(company),
+        ("account_type", "=", "equity_unaffected"),
+    ])
+    if len(accounts) > 1:
+        raise UserError(_(
+            "Multiple Current-Year-Earnings accounts found for %(company)s: "
+            "%(codes)s. Year-end close cannot proceed until only one "
+            "remains.",
+            company=company.display_name,
+            codes=", ".join(accounts.mapped("code")),
+        ))
+    return accounts
+
+
+def get_retained_earnings_account(env, company, config: Dict):
+    """Resolve *company*'s configured Retained Earnings account by code.
+
+    The code comes from *config* (see ``get_year_end_close_config``,
+    default ``3200``), so a chart that doesn't use that literal can be
+    repointed via the ``qbo_to_odoo.year_end_close.retained_earnings_code``
+    ``ir.config_parameter`` without a code change. Searched
+    ``active_test=False`` for symmetry with the CYE lookup; unlike the CYE
+    account, an archived RE account is not auto-unarchived here — 322000
+    being archived is the specific, confirmed trap this design guards
+    against, not the RE account.
+
+    :return: the ``account.account`` recordset (empty if the code doesn't
+        resolve).
+    """
+    Account = env["account.account"].with_context(active_test=False)
+    return Account.search([
+        *Account._check_company_domain(company),
+        ("code", "=", config["retained_earnings_code"]),
+    ], limit=1)
+
+
+def validate_year_end_close_accounts(env, company, config: Dict):
+    """Resolve and validate the CYE/RE accounts, failing loudly on
+    misconfiguration.
+
+    Deliberately only ever called from the *load* step, after the
+    ``enabled`` gate has already been checked — a migration that hasn't
+    opted into year-end close must never be affected by these checks,
+    even if its chart of accounts happens to have an unrelated account
+    coded like the default ``3200`` or two accounts typed
+    ``equity_unaffected``.
+
+    :raises UserError: if the Current-Year-Earnings account does not
+        resolve to exactly one record, if the Retained Earnings account
+        does not resolve to exactly one record, or if the resolved RE
+        account is not a carry-forward equity account
+        (``account_type == 'equity'``) — pointing it at a P&L or
+        ``equity_unaffected`` account would leave the report's
+        Undistributed Profits/Losses line non-zero instead of clearing it
+        (see ``account_account._compute_include_initial_balance``).
+    :return: ``(cye_account, re_account)`` singleton recordsets.
+    """
+    cye_account = get_unaffected_earnings_account(env, company)
+    if not cye_account:
+        raise UserError(_(
+            "Year-end close is enabled but no Current-Year-Earnings "
+            "account (account_type = 'equity_unaffected') was found for "
+            "%(company)s.",
+            company=company.display_name,
+        ))
+
+    re_account = get_retained_earnings_account(env, company, config)
+    if not re_account:
+        raise UserError(_(
+            "Year-end close is enabled but the configured Retained "
+            "Earnings account (code %(code)s) was not found for "
+            "%(company)s.",
+            code=config["retained_earnings_code"],
+            company=company.display_name,
+        ))
+    if re_account.account_type != "equity":
+        raise UserError(_(
+            "Year-end close: the configured Retained Earnings account "
+            "%(code)s must be a carry-forward equity account "
+            "(account_type = 'equity'); found %(type)s instead. Posting "
+            "would leave the Undistributed Profits/Losses line non-zero.",
+            code=re_account.code,
+            type=re_account.account_type,
+        ))
+
+    return cye_account, re_account
+
+
+def get_year_end_close_journal(env, company):
+    """Resolve the miscellaneous journal for the closing entries.
+
+    Same convention as ``qbo.migration.report``'s opening-balance entry:
+    prefer the journal coded ``MISC``, fall back to any ``general``
+    journal for *company*.
+    """
+    Journal = env["account.journal"]
+    domain = [("type", "=", "general"), ("company_id", "=", company.id)]
+    journal = Journal.search(domain + [("code", "=", "MISC")], limit=1)
+    if not journal:
+        journal = Journal.search(domain, limit=1)
+    return journal
+
+
+def compute_fiscal_year_close_rows(
+    env, company, config: Dict
+) -> List[Tuple[int, date, float, int, int]]:
+    """Compute one closing row per already-closed fiscal year.
+
+    Enumerates fiscal years from the one containing the earliest posted
+    P&L move line up to (but excluding) the fiscal year containing today,
+    with boundaries always read from ``company.compute_fiscalyear_dates``
+    (never hardcoded — a change to ``fiscalyear_last_month``/``_day``
+    shifts every result). For each FY, sums the ``balance`` (debit −
+    credit) of every posted move line on an income/expense account dated
+    within that FY's window; a negative sum is a net profit.
+
+    Side-effect-free (only reads), so it is testable directly against a
+    seeded DB without going through the ``qbo.year.end.close`` pipeline —
+    the same seam ``build_cogs_completion_transactions`` gives the COGS
+    completion logic.
+
+    :param env: Odoo environment.
+    :param company: a single ``res.company`` record.
+    :param config: as returned by ``get_year_end_close_config`` — only
+        ``retained_earnings_code`` is used here.
+    :return: a list of ``(fy_label, date_to, signed_result,
+        cye_account_id, re_account_id)`` tuples, one per closed FY whose
+        signed result is non-zero (a zero-result FY needs no closing
+        entry and is omitted). ``fy_label`` is ``date_to.year``.
+    """
+    cye_account = get_unaffected_earnings_account(env, company)
+    re_account = get_retained_earnings_account(env, company, config)
+    if not cye_account or not re_account:
+        _logger.warning(
+            "Year-end close: could not resolve the Current-Year-Earnings "
+            "and/or Retained Earnings account for %s — nothing to close",
+            company.display_name,
+        )
+        return []
+
+    pnl_accounts = env["account.account"].search([
+        *env["account.account"]._check_company_domain(company),
+        ("internal_group", "in", list(_PNL_INTERNAL_GROUPS)),
+    ])
+    if not pnl_accounts:
+        return []
+
+    AccountMoveLine = env["account.move.line"]
+    base_domain = [
+        ("parent_state", "=", "posted"),
+        ("account_id", "in", pnl_accounts.ids),
+        ("company_id", "=", company.id),
+    ]
+
+    earliest = AccountMoveLine.search(base_domain, order="date asc", limit=1)
+    if not earliest:
+        return []
+
+    open_fy = company.compute_fiscalyear_dates(date.today())
+    fy_window = company.compute_fiscalyear_dates(earliest.date)
+
+    rows: List[Tuple[int, date, float, int, int]] = []
+    while fy_window["date_from"] < open_fy["date_from"]:
+        date_from, date_to = fy_window["date_from"], fy_window["date_to"]
+        lines = AccountMoveLine.search(
+            base_domain + [("date", ">=", date_from), ("date", "<=", date_to)]
+        )
+        signed_result = round(sum(lines.mapped("balance")), 2)
+        fy_label = date_to.year
+
+        if signed_result:
+            rows.append(
+                (fy_label, date_to, signed_result, cye_account.id, re_account.id)
+            )
+
+        fy_window = company.compute_fiscalyear_dates(date_to + timedelta(days=1))
+
+    return rows
+
+
+def build_year_end_close_move_vals(
+    fy_label: int,
+    date_to: date,
+    signed_result: float,
+    cye_account_id: int,
+    re_account_id: int,
+    journal_id: int,
+) -> Dict:
+    """Build a balanced year-end closing ``account.move`` vals dict.
+
+    Pure / side-effect-free — no DB access, just arithmetic and a vals
+    dict — unit-testable without a database, mirroring
+    ``build_cogs_completion_transactions``'s DB-free construction seam.
+
+    Sign convention: *signed_result* is the FY's posted P&L balance
+    (debit − credit); negative means a net profit. The Retained Earnings
+    leg's balance changes by ``+signed_result`` and the Current-Year-
+    Earnings leg's balance changes by ``-signed_result`` — so a profit
+    year (negative ``signed_result``) debits the CYE account and credits
+    Retained Earnings by the profit amount (CYE clears toward zero, RE
+    grows); a loss year reverses both legs.
+
+    :return: an ``account.move`` vals dict, balanced by construction,
+        dated ``date_to``, with ``ref = f"{YEAR_END_CLOSE_REF_PREFIX}
+        {fy_label}"`` — the idempotency / drift-exclusion stamp.
+    """
+    return {
+        "move_type": "entry",
+        "journal_id": journal_id,
+        "date": date_to,
+        "ref": f"{YEAR_END_CLOSE_REF_PREFIX}{fy_label}",
+        "line_ids": [
+            Command.create({
+                "account_id": cye_account_id,
+                "name": f"Year-end close FY{fy_label}",
+                "debit": max(-signed_result, 0.0),
+                "credit": max(signed_result, 0.0),
+            }),
+            Command.create({
+                "account_id": re_account_id,
+                "name": f"Year-end close FY{fy_label}",
+                "debit": max(signed_result, 0.0),
+                "credit": max(-signed_result, 0.0),
+            }),
+        ],
+    }

--- a/qbo_to_odoo/models/pipelines/year_end_close.py
+++ b/qbo_to_odoo/models/pipelines/year_end_close.py
@@ -1,0 +1,165 @@
+"""QBO Year-End Closing Entries Finalizer.
+
+Posts one balanced closing entry per already-closed fiscal year, sweeping
+that year's net P&L result from the Current-Year-Earnings account (322000
+in this migration, resolved by ``account_type`` rather than hardcoded) to
+the configured Retained Earnings account (3200 by default) — the same
+"close the books" sweep a real year-end performs. This makes Odoo's
+report-only "Undistributed Profits/Losses" line read 0.00 for every closed
+fiscal year, leaving only the currently-open FY unallocated.
+
+Config-gated (default disabled) via the
+``qbo_to_odoo.year_end_close.enabled`` ``ir.config_parameter`` — every
+migration must opt in explicitly. Idempotent via the
+``QBO_YE_CLOSE:<FY>`` ``account.move.ref`` stamp, mirroring the
+``QBO_EXCH:``/``QBO_CENT_TRUEUP`` conventions used elsewhere in this
+module.
+"""
+
+import logging
+from typing import Dict, List, Tuple
+
+from odoo import models
+
+from odoo.addons.etl_framework import ETL, ETLContext
+
+from .gl_helpers import (
+    YEAR_END_CLOSE_ENABLED_PARAM,
+    build_year_end_close_move_vals,
+    compute_fiscal_year_close_rows,
+    get_year_end_close_config,
+    get_year_end_close_journal,
+    validate_year_end_close_accounts,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+@ETL.pipeline(
+    target_model="account.move",
+    importer_name="qbo.year.end.close",
+    depends_on=["qbo.account.finalizer"],
+)
+class QboYearEndClose(models.AbstractModel):
+    """Post year-end closing entries for every closed fiscal year.
+
+    Runs terminal — AFTER ``qbo.account.finalizer`` (reconciliation retry,
+    realized-FX true-up, and cent-scale rounding parity) — so each fiscal
+    year is closed off a *final* posted ledger. The heavy computation
+    (enumerating closed FYs off ``res.company`` config and summing each
+    year's signed P&L balance) lives in the side-effect-free
+    ``compute_fiscal_year_close_rows`` helper; the balanced move vals come
+    from the pure ``build_year_end_close_move_vals`` builder. This class
+    only wires those together and performs the two mutations: unarchiving
+    the CYE account (``qbo.account.finalizer`` archives every account QBO
+    marked inactive, and the CYE account may be one of them even though it
+    must stay postable) and posting/skipping idempotently.
+    """
+
+    _name = "qbo.year.end.close"
+    _description = "QBO Year-End Close Finalizer"
+
+    @ETL.extract()
+    def extract_year_end_close_rows(
+        self, ctx: ETLContext
+    ) -> List[Tuple]:
+        """Compute one closing row per already-closed fiscal year.
+
+        Gated on ``enabled`` purely to avoid wasted computation and the
+        "duplicate CYE account" ``UserError`` (see
+        ``get_unaffected_earnings_account``) on every migration that
+        hasn't opted into year-end close — this pipeline is registered
+        unconditionally, so extract would otherwise run for every
+        company on every migration. The pure
+        ``compute_fiscal_year_close_rows`` helper itself remains
+        gate-free and directly unit-testable; the loud
+        misconfiguration *validation* (does the CYE/RE account resolve
+        and is RE the right type) still lives entirely in
+        ``load_year_end_close``, alongside the mutations it guards.
+        """
+        env = ctx.env
+        config = get_year_end_close_config(env)
+        if not config["enabled"]:
+            return []
+        rows = compute_fiscal_year_close_rows(env, env.company, config)
+        _logger.info(
+            "Year-end close: %d fiscal year(s) with a non-zero result",
+            len(rows),
+        )
+        return rows
+
+    @ETL.transform()
+    def transform_year_end_close(
+        self, ctx: ETLContext, extracted: Dict
+    ) -> List[Dict]:
+        """Build a balanced move-vals dict per row via the pure builder."""
+        rows = extracted.get("extract_year_end_close_rows", [])
+        if not rows:
+            return []
+
+        journal = get_year_end_close_journal(ctx.env, ctx.env.company)
+        if not journal:
+            _logger.warning(
+                "Year-end close: no miscellaneous journal found — "
+                "nothing to post"
+            )
+            return []
+
+        return [
+            build_year_end_close_move_vals(
+                fy_label,
+                date_to,
+                signed_result,
+                cye_account_id,
+                re_account_id,
+                journal.id,
+            )
+            for fy_label, date_to, signed_result, cye_account_id, re_account_id
+            in rows
+        ]
+
+    @ETL.load()
+    def load_year_end_close(self, ctx: ETLContext, transformed: Dict) -> None:
+        """Config-gate, unarchive the CYE account, post/skip idempotently."""
+        env = ctx.env
+        config = get_year_end_close_config(env)
+        if not config["enabled"]:
+            _logger.info(
+                "Year-end close skipped: %s is disabled",
+                YEAR_END_CLOSE_ENABLED_PARAM,
+            )
+            return
+
+        # RE account validation happens as a side effect of this call; the
+        # RE account itself is already baked into transformed move_vals.
+        cye_account, _re_account = validate_year_end_close_accounts(
+            env, env.company, config
+        )
+        if not cye_account.active:
+            cye_account.write({"active": True})
+            _logger.info(
+                "Year-end close: unarchived CYE account %s (%s)",
+                cye_account.code, cye_account.name,
+            )
+
+        move_vals_list = transformed.get("transform_year_end_close", [])
+        if not move_vals_list:
+            _logger.info("Year-end close: nothing to post")
+            return
+
+        AccountMove = env["account.move"]
+        posted = 0
+        for vals in move_vals_list:
+            ref = vals["ref"]
+            if AccountMove.search_count([("ref", "=", ref)]):
+                continue
+            with ctx.skippable(ref):
+                move = AccountMove.create(vals)
+                move.action_post()
+                posted += 1
+
+        _logger.info(
+            "Year-end close: posted %d closing entry(ies) (%d already "
+            "present)",
+            posted, len(move_vals_list) - posted,
+        )

--- a/qbo_to_odoo/models/qbo_migration_report.py
+++ b/qbo_to_odoo/models/qbo_migration_report.py
@@ -298,6 +298,12 @@ class QboMigrationReport(models.Model):
         QBO so no source filter is needed.  Using all posted moves avoids
         false negatives from enriched payments whose ``qbo_*_id`` lives on
         ``account.payment`` rather than ``account.move``.
+
+        Excludes ``qbo.year.end.close`` moves (``ref LIKE 'QBO_YE_CLOSE:%'``):
+        those are deliberately absent from QBO's GL cache (QBO never closes
+        the books in Odoo's sense), so including them would manufacture
+        drift on the Retained Earnings / Current-Year-Earnings accounts
+        that nets to zero and isn't a real migration discrepancy.
         """
         cr = self.env.cr
         cr.execute(
@@ -311,6 +317,7 @@ class QboMigrationReport(models.Model):
               JOIN account_account aa ON aml.account_id = aa.id
               JOIN account_move am ON aml.move_id = am.id
              WHERE am.state = 'posted'
+               AND (am.ref IS NULL OR am.ref NOT LIKE 'QBO\\_YE\\_CLOSE:%')
              GROUP BY aa.id, code, acct_name
              ORDER BY code
         """
@@ -341,6 +348,7 @@ class QboMigrationReport(models.Model):
               JOIN account_account aa ON aml.account_id = aa.id
               JOIN account_move am ON aml.move_id = am.id
              WHERE am.state = 'posted'
+               AND (am.ref IS NULL OR am.ref NOT LIKE 'QBO\\_YE\\_CLOSE:%')
              ORDER BY am.date, am.id
         """
         )

--- a/qbo_to_odoo/tests/__init__.py
+++ b/qbo_to_odoo/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_product_name_sales_description
 from . import test_product_name_locale
 from . import test_bank_journal_suspense
 from . import test_cogs_completion
+from . import test_year_end_close

--- a/qbo_to_odoo/tests/test_archive_deleted_journals.py
+++ b/qbo_to_odoo/tests/test_archive_deleted_journals.py
@@ -1,13 +1,16 @@
 """Tests for the end-of-import 'deleted' journal archival step.
 
-Acceptance criteria (task 3818):
+Acceptance criteria (task 3818, AC2 revised when the archival moved to the
+terminal ``qbo.journal.finalizer`` pipeline):
 1. At the end of the QBO import, every account.journal whose name contains
    "deleted" is archived (active=False). Matching is case-insensitive, so
    journals named with any casing of "deleted" / "(Deleted)" are archived,
    while a normally-named journal is left untouched.
-2. The step runs automatically as part of the import — it is invoked from the
-   bank-journal pipeline's load step (QboBankJournalProcessor.load_journals),
-   which the orchestrated import runs. The test exercises the cleanup method
+2. The archival runs from the terminal ``qbo.journal.finalizer`` load step —
+   and must NOT run from the bank-journal pipeline's ``load_journals``: that
+   pipeline runs before the move-posting pipelines, and archiving there makes
+   posts into the deleted journals fail ("cannot post an entry in an archived
+   journal"), stranding moves in draft. The tests exercise both load steps
    directly (no live QBO connection needed), as the existing pipeline tests do.
 3. Idempotent — invoking the cleanup a second time does not error and leaves the
    deleted-named journals archived.
@@ -76,24 +79,34 @@ class TestArchiveDeletedJournals(TransactionCase):
             "a normally-named journal must NOT be archived",
         )
 
-    def test_ac2_runs_from_load_journals(self):
-        """AC2: the cleanup runs automatically via the pipeline load step.
+    def test_ac2_runs_from_finalizer_not_load_journals(self):
+        """AC2: archival fires from the terminal finalizer, NOT journal creation.
 
-        load_journals with no journals to create still triggers the archival
-        cleanup, so an orchestrated import that creates no new bank journals
-        still cleans up QBO 'deleted' journals.
+        The bank-journal pipeline runs before the move-posting pipelines, so
+        archiving there breaks posting into the deleted journals (moves left
+        in draft). The cleanup must therefore be a no-op in load_journals and
+        run from qbo.journal.finalizer's load step instead.
         """
         ctx = _make_ctx(self.env)
 
         self.deleted_lower.with_context(active_test=False).write({"active": True})
 
-        # No 'transform_journals' key -> no creation, but cleanup must still run.
+        # Journal creation must NOT archive — downstream pipelines still need
+        # to post into the deleted journals.
         self.processor.load_journals(ctx, {})
+        self.deleted_lower.invalidate_recordset()
+        self.assertTrue(
+            self.deleted_lower.with_context(active_test=False).active,
+            "load_journals must NOT archive 'deleted' journals (posting into "
+            "them happens later in the import)",
+        )
 
+        # The terminal finalizer is what archives.
+        self.env["qbo.journal.finalizer"].archive_deleted_journals(ctx, {})
         self.deleted_lower.invalidate_recordset()
         self.assertFalse(
             self.deleted_lower.with_context(active_test=False).active,
-            "load_journals must invoke the 'deleted' cleanup even with no new journals",
+            "qbo.journal.finalizer must archive 'deleted' journals",
         )
 
     def test_ac3_idempotent_on_rerun(self):

--- a/qbo_to_odoo/tests/test_year_end_close.py
+++ b/qbo_to_odoo/tests/test_year_end_close.py
@@ -1,0 +1,420 @@
+"""Tests for the qbo.year.end.close finalizer pipeline (task 4096).
+
+Posts one balanced closing entry per already-closed fiscal year, sweeping
+that year's net P&L result from the company's Current-Year-Earnings (CYE)
+account into the configured Retained Earnings (RE) account, so Odoo's
+report-only "Undistributed Profits/Losses" line reads 0.00 for every
+closed fiscal year.
+
+Acceptance criteria covered:
+1. ``build_year_end_close_move_vals`` is a pure, balanced, correctly
+   signed and correctly stamped move-vals builder (profit year and loss
+   year).
+2. ``compute_fiscal_year_close_rows`` derives its FY boundaries from
+   ``company.compute_fiscalyear_dates`` (never hardcoded) — changing
+   ``fiscalyear_last_month``/``_day`` shifts both the boundaries and the
+   per-year results for the same underlying ledger data.
+3. The earliest posted fiscal year needs no stub special-casing: its
+   result naturally equals only the partial-period activity actually
+   posted inside it.
+4. AC #2: the load pass is idempotent — running it twice posts exactly
+   one move per closed FY and leaves the CYE account active (unarchived
+   exactly once, not re-duplicated).
+5. AC #5/#6/#7: closing entries are correct and balanced, the FY
+   containing "today" is never closed, P&L account balances are
+   unaffected by the close, and the QBO_YE_CLOSE-stamped moves are
+   excluded from ``qbo.migration.report._get_odoo_trial_balance``.
+6. The pass is config-gated: disabled (the default) posts nothing and
+   never touches the archived CYE account.
+7. RE-account resolution validation (this task's fix to the WIP): the
+   load step fails loudly, rather than silently posting misdirected
+   moves or silently no-op'ing, when the configured RE account doesn't
+   resolve or isn't a carry-forward equity account.
+"""
+
+from datetime import date
+
+from odoo.exceptions import UserError
+from odoo.fields import Command
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.etl_framework import ETLContext
+from odoo.addons.qbo_to_odoo.models.pipelines.gl_helpers import (
+    YEAR_END_CLOSE_ENABLED_PARAM,
+    YEAR_END_CLOSE_RE_CODE_PARAM,
+    YEAR_END_CLOSE_REF_PREFIX,
+    build_year_end_close_move_vals,
+    compute_fiscal_year_close_rows,
+)
+
+
+def _make_ctx(env):
+    """Build a minimal ETLContext backed by the Odoo test env."""
+    return ETLContext(cr=None, env=env)
+
+
+@tagged("post_install", "-at_install", "qbo_year_end_close")
+class TestBuildYearEndCloseMoveVals(TransactionCase):
+    """AC #1: the pure move-vals builder — no DB needed."""
+
+    def test_profit_year_debits_cye_credits_re(self):
+        vals = build_year_end_close_move_vals(
+            2015, date(2015, 10, 31), -46393.56, cye_account_id=101,
+            re_account_id=202, journal_id=303,
+        )
+        self.assertEqual(vals["ref"], "QBO_YE_CLOSE:2015")
+        self.assertEqual(vals["date"], date(2015, 10, 31))
+        self.assertEqual(vals["journal_id"], 303)
+
+        lines = {l[2]["account_id"]: l[2] for l in vals["line_ids"]}
+        self.assertEqual(lines[101]["debit"], 46393.56)
+        self.assertEqual(lines[101]["credit"], 0.0)
+        self.assertEqual(lines[202]["debit"], 0.0)
+        self.assertEqual(lines[202]["credit"], 46393.56)
+
+        total_debit = sum(l[2]["debit"] for l in vals["line_ids"])
+        total_credit = sum(l[2]["credit"] for l in vals["line_ids"])
+        self.assertEqual(total_debit, total_credit, "move must be balanced")
+
+    def test_loss_year_reverses_legs(self):
+        vals = build_year_end_close_move_vals(
+            2016, date(2016, 10, 31), 166263.98, cye_account_id=101,
+            re_account_id=202, journal_id=303,
+        )
+        self.assertEqual(vals["ref"], "QBO_YE_CLOSE:2016")
+
+        lines = {l[2]["account_id"]: l[2] for l in vals["line_ids"]}
+        self.assertEqual(lines[101]["debit"], 0.0)
+        self.assertEqual(lines[101]["credit"], 166263.98)
+        self.assertEqual(lines[202]["debit"], 166263.98)
+        self.assertEqual(lines[202]["credit"], 0.0)
+
+        total_debit = sum(l[2]["debit"] for l in vals["line_ids"])
+        total_credit = sum(l[2]["credit"] for l in vals["line_ids"])
+        self.assertEqual(total_debit, total_credit, "move must be balanced")
+
+
+@tagged("post_install", "-at_install", "qbo_year_end_close")
+class TestYearEndClosePipeline(TransactionCase):
+    """AC #2-#7: the DB-backed row computation and the ETL pipeline."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+
+        Account = cls.env["account.account"]
+
+        # This test company has no installed chart of accounts. Odoo lazily
+        # auto-provisions two chartless-fallback placeholder accounts
+        # (xml_ids account.<company>_profit_or_loss /
+        # account.<company>_retained_earnings) the first time accounting
+        # config is touched — and in this Odoo version BOTH default to
+        # account_type='equity_unaffected'. That is exactly the
+        # "duplicate CYE account" scenario the pipeline's
+        # get_unaffected_earnings_account() is designed to refuse (see
+        # gl_helpers.py) — appropriate for a company mid-migration, but it
+        # would make every fixture in this file trip that guard by
+        # accident. Neutralize them so this test's own dedicated CYE/RE
+        # accounts are the only equity_unaffected candidate, matching the
+        # real target (a company with a genuine, already-migrated CoA
+        # where a stray duplicate is the true exceptional case under
+        # test).
+        stray_cye = Account.with_context(active_test=False).search([
+            ("account_type", "=", "equity_unaffected"),
+            *Account._check_company_domain(cls.company),
+        ])
+        if stray_cye:
+            stray_cye.write({"account_type": "asset_current"})
+
+        cls.cye_account = Account.create({
+            "name": "Current Year Earnings (YEC Test)",
+            "code": "YEC.CYE",
+            "account_type": "equity_unaffected",
+        })
+        cls.re_account = Account.create({
+            "name": "Retained Earnings (YEC Test)",
+            "code": "YEC.RE",
+            "account_type": "equity",
+        })
+        cls.income_account = Account.create({
+            "name": "Sales (YEC Test)", "code": "YEC.INC", "account_type": "income",
+        })
+        cls.expense_account = Account.create({
+            "name": "Expenses (YEC Test)", "code": "YEC.EXP", "account_type": "expense",
+        })
+        cls.bank_account = Account.create({
+            "name": "Bank (YEC Test)", "code": "YEC.BANK", "account_type": "asset_current",
+        })
+
+        cls.journal = cls.env["account.journal"].search([
+            ("type", "=", "general"), ("company_id", "=", cls.company.id),
+        ], limit=1)
+        if not cls.journal:
+            cls.journal = cls.env["account.journal"].create({
+                "name": "Miscellaneous (YEC Test)",
+                "code": "MISC",
+                "type": "general",
+                "company_id": cls.company.id,
+            })
+
+    def _post_pnl_move(self, move_date, expense_debit, income_credit):
+        """Post a 3-line balanced move: DR Bank (plug), DR Expense, CR Income.
+
+        The Bank leg is a non-P&L plug so the P&L legs alone can net to a
+        non-zero signed result while the whole move still balances.
+        """
+        bank_debit = round(income_credit - expense_debit, 2)
+        lines = [
+            Command.create({
+                "account_id": self.expense_account.id,
+                "name": "YEC test expense",
+                "debit": expense_debit,
+                "credit": 0.0,
+            }),
+            Command.create({
+                "account_id": self.income_account.id,
+                "name": "YEC test income",
+                "debit": 0.0,
+                "credit": income_credit,
+            }),
+        ]
+        if bank_debit >= 0:
+            lines.append(Command.create({
+                "account_id": self.bank_account.id,
+                "name": "YEC test plug",
+                "debit": bank_debit,
+                "credit": 0.0,
+            }))
+        else:
+            lines.append(Command.create({
+                "account_id": self.bank_account.id,
+                "name": "YEC test plug",
+                "debit": 0.0,
+                "credit": -bank_debit,
+            }))
+        move = self.env["account.move"].create({
+            "move_type": "entry",
+            "journal_id": self.journal.id,
+            "date": move_date,
+            "line_ids": lines,
+        })
+        move.action_post()
+        return move
+
+    def _config(self, retained_earnings_code=None):
+        return {"retained_earnings_code": retained_earnings_code or self.re_account.code}
+
+    def _run_pipeline(self):
+        model = self.env["qbo.year.end.close"]
+        ctx = _make_ctx(self.env)
+        extracted = {
+            "extract_year_end_close_rows": model.extract_year_end_close_rows(ctx)
+        }
+        transformed = {
+            "transform_year_end_close": model.transform_year_end_close(ctx, extracted)
+        }
+        model.load_year_end_close(ctx, transformed)
+        return extracted, transformed
+
+    # -- AC #2/#3: FY enumeration, boundaries, and the natural stub-year --
+
+    def test_per_fy_results_and_stub_year(self):
+        """Calendar-year default: two closed FYs, first one is a natural stub."""
+        self._post_pnl_move(date(2020, 6, 15), expense_debit=300.0, income_credit=800.0)
+        self._post_pnl_move(date(2021, 6, 15), expense_debit=200.0, income_credit=500.0)
+
+        rows = compute_fiscal_year_close_rows(
+            self.env, self.company, self._config()
+        )
+        by_label = {r[0]: r for r in rows}
+
+        self.assertIn(2020, by_label)
+        fy_label, date_to, signed_result, cye_id, re_id = by_label[2020]
+        self.assertEqual(date_to, date(2020, 12, 31))
+        self.assertEqual(signed_result, -500.0, "FY2020: 800 income - 300 expense = 500 profit")
+        self.assertEqual(cye_id, self.cye_account.id)
+        self.assertEqual(re_id, self.re_account.id)
+
+        self.assertIn(2021, by_label)
+        _, date_to_2021, signed_result_2021, _, _ = by_label[2021]
+        self.assertEqual(date_to_2021, date(2021, 12, 31))
+        self.assertEqual(signed_result_2021, -300.0, "FY2021: 500 income - 200 expense = 300 profit")
+
+    def test_boundary_shift_not_hardcoded(self):
+        """Changing fiscalyear_last_month/_day shifts the FY windows for the same ledger."""
+        self._post_pnl_move(date(2020, 6, 15), expense_debit=300.0, income_credit=800.0)
+        self._post_pnl_move(date(2021, 6, 15), expense_debit=200.0, income_credit=500.0)
+
+        self.company.write({"fiscalyear_last_month": "6", "fiscalyear_last_day": 30})
+
+        rows = compute_fiscal_year_close_rows(
+            self.env, self.company, self._config()
+        )
+        by_label = {r[0]: r for r in rows}
+
+        self.assertIn(2020, by_label)
+        self.assertEqual(
+            by_label[2020][1], date(2020, 6, 30),
+            "FY-end must follow the new fiscalyear_last_month/_day config",
+        )
+        self.assertEqual(by_label[2020][2], -500.0)
+
+        self.assertIn(2021, by_label)
+        self.assertEqual(by_label[2021][1], date(2021, 6, 30))
+        self.assertEqual(by_label[2021][2], -300.0)
+
+    def test_zero_result_fy_is_skipped(self):
+        """A closed FY whose income/expense lines net to exactly zero needs no close."""
+        self._post_pnl_move(date(2020, 6, 15), expense_debit=500.0, income_credit=500.0)
+
+        rows = compute_fiscal_year_close_rows(
+            self.env, self.company, self._config()
+        )
+        self.assertFalse(
+            [r for r in rows if r[0] == 2020],
+            "a zero-result FY must be omitted, not produce a zero-amount close",
+        )
+
+    # -- AC #4/#5/#6/#7: the full pipeline --
+
+    def test_idempotent_double_run(self):
+        self._post_pnl_move(date(2020, 6, 15), expense_debit=300.0, income_credit=800.0)
+        self._post_pnl_move(date(2021, 6, 15), expense_debit=200.0, income_credit=500.0)
+        self.cye_account.write({"active": False})
+        self.env["ir.config_parameter"].sudo().set_param(YEAR_END_CLOSE_ENABLED_PARAM, "1")
+        self.env["ir.config_parameter"].sudo().set_param(
+            YEAR_END_CLOSE_RE_CODE_PARAM, self.re_account.code
+        )
+
+        self._run_pipeline()
+        AccountMove = self.env["account.move"]
+        first_run_ids = AccountMove.search(
+            [("ref", "like", f"{YEAR_END_CLOSE_REF_PREFIX}%")]
+        ).ids
+        self.assertEqual(len(first_run_ids), 2)
+        self.assertTrue(self.cye_account.active, "CYE account must be unarchived")
+
+        self._run_pipeline()
+        second_run_ids = AccountMove.search(
+            [("ref", "like", f"{YEAR_END_CLOSE_REF_PREFIX}%")]
+        ).ids
+        self.assertEqual(
+            sorted(second_run_ids), sorted(first_run_ids),
+            "re-running must not create duplicate closing moves",
+        )
+        self.assertTrue(self.cye_account.active)
+
+    def test_close_correctness_open_fy_and_report_exclusion(self):
+        self._post_pnl_move(date(2020, 6, 15), expense_debit=300.0, income_credit=800.0)
+        self._post_pnl_move(date(2021, 6, 15), expense_debit=200.0, income_credit=500.0)
+        # Activity in the currently-open FY must never be closed (AC #5).
+        self._post_pnl_move(date.today(), expense_debit=0.0, income_credit=100.0)
+
+        pnl_accounts = self.income_account | self.expense_account
+        pnl_balance_before = sum(
+            self.env["account.move.line"].search([
+                ("account_id", "in", pnl_accounts.ids),
+                ("parent_state", "=", "posted"),
+            ]).mapped("balance")
+        )
+
+        self.env["ir.config_parameter"].sudo().set_param(YEAR_END_CLOSE_ENABLED_PARAM, "1")
+        self.env["ir.config_parameter"].sudo().set_param(
+            YEAR_END_CLOSE_RE_CODE_PARAM, self.re_account.code
+        )
+        self._run_pipeline()
+
+        AccountMove = self.env["account.move"]
+        closes = AccountMove.search([("ref", "like", f"{YEAR_END_CLOSE_REF_PREFIX}%")])
+        self.assertEqual(
+            len(closes), 2,
+            "only the two closed FYs are stamped — the open FY is never closed",
+        )
+        for move in closes:
+            self.assertEqual(move.state, "posted")
+            self.assertEqual(move.journal_id, self.journal)
+            self.assertEqual(
+                sum(move.line_ids.mapped("debit")),
+                sum(move.line_ids.mapped("credit")),
+            )
+
+        # Both FYs were profit years: RE nets credited, CYE nets debited by
+        # the same accumulated amount (500 + 300 = 800).
+        AccountMoveLine = self.env["account.move.line"]
+        re_balance = sum(
+            AccountMoveLine.search([("account_id", "=", self.re_account.id)])
+            .mapped("balance")
+        )
+        cye_balance = sum(
+            AccountMoveLine.search([("account_id", "=", self.cye_account.id)])
+            .mapped("balance")
+        )
+        self.assertAlmostEqual(re_balance, -800.0, places=2)
+        self.assertAlmostEqual(cye_balance, 800.0, places=2)
+
+        # AC #6: P&L account balances are unaffected by the close.
+        pnl_balance_after = sum(
+            self.env["account.move.line"].search([
+                ("account_id", "in", pnl_accounts.ids),
+                ("parent_state", "=", "posted"),
+            ]).mapped("balance")
+        )
+        self.assertAlmostEqual(pnl_balance_before, pnl_balance_after, places=2)
+
+        # AC #7 (in-repo piece): the report excludes QBO_YE_CLOSE moves, so
+        # the RE/CYE test accounts — touched only by the closing entries —
+        # show no activity in the report's trial balance.
+        report_model = self.env["qbo.migration.report"]
+        tb, _txns = report_model._get_odoo_trial_balance()
+        self.assertNotIn(self.re_account.code, tb)
+        self.assertNotIn(self.cye_account.code, tb)
+
+    def test_config_gate_disabled_posts_nothing(self):
+        self._post_pnl_move(date(2020, 6, 15), expense_debit=300.0, income_credit=800.0)
+        self.cye_account.write({"active": False})
+        self.env["ir.config_parameter"].sudo().set_param(YEAR_END_CLOSE_ENABLED_PARAM, "0")
+
+        self._run_pipeline()
+
+        self.assertEqual(
+            self.env["account.move"].search_count(
+                [("ref", "like", f"{YEAR_END_CLOSE_REF_PREFIX}%")]
+            ),
+            0,
+        )
+        self.assertFalse(
+            self.cye_account.active,
+            "a disabled pass must never touch the archived CYE account",
+        )
+
+    # -- Fail-loud validation (this task's fix) --
+
+    def test_re_account_wrong_type_raises(self):
+        """RE code pointing at a non-equity account must abort loudly, not post."""
+        self._post_pnl_move(date(2020, 6, 15), expense_debit=300.0, income_credit=800.0)
+        self.env["ir.config_parameter"].sudo().set_param(YEAR_END_CLOSE_ENABLED_PARAM, "1")
+        self.env["ir.config_parameter"].sudo().set_param(
+            YEAR_END_CLOSE_RE_CODE_PARAM, self.income_account.code
+        )
+
+        with self.assertRaises(UserError):
+            self._run_pipeline()
+
+        self.assertEqual(
+            self.env["account.move"].search_count(
+                [("ref", "like", f"{YEAR_END_CLOSE_REF_PREFIX}%")]
+            ),
+            0,
+            "no partial/misdirected close may be posted when validation fails",
+        )
+
+    def test_re_account_missing_raises(self):
+        self._post_pnl_move(date(2020, 6, 15), expense_debit=300.0, income_credit=800.0)
+        self.env["ir.config_parameter"].sudo().set_param(YEAR_END_CLOSE_ENABLED_PARAM, "1")
+        self.env["ir.config_parameter"].sudo().set_param(
+            YEAR_END_CLOSE_RE_CODE_PARAM, "YEC.NONEXISTENT"
+        )
+
+        with self.assertRaises(UserError):
+            self._run_pipeline()


### PR DESCRIPTION
## Summary

Adds the config-gated `qbo.year.end.close` ETL finalizer pipeline (task 4096):
enumerates every already-closed fiscal year from
`company.compute_fiscalyear_dates` (never hardcoded), sums each year's posted
P&L result, and posts one balanced closing move per year sweeping the result
from the Current-Year-Earnings account (`account_type=equity_unaffected`)
into the configured Retained Earnings account. Idempotent via a
`QBO_YE_CLOSE:<FY>` `account.move.ref` stamp, which `qbo_migration_report`
also excludes from its drift-comparison queries so the report keeps matching
QBO's GL cache (which never sees these entries).

Default-inert (`qbo_to_odoo.year_end_close.enabled=0`) so no existing
migration is affected; a migration opts in via that flag plus
`qbo_to_odoo.year_end_close.retained_earnings_code`.

The load step fails loudly rather than silently misposting when the CYE/RE
accounts don't resolve to exactly one record each, or when the configured RE
account isn't a carry-forward equity account (`account_type=equity`, not
`equity_unaffected`) — pointing it at the wrong account would leave the
report's Undistributed Profits/Losses line non-zero instead of clearing it.
The extract step is also gated on `enabled`, both to avoid wasted
per-migration computation and to avoid the loud CYE-duplicate check hitting
migrations that never opted in.

Also includes a companion test fix: the deleted-journal archival test was
retargeted to match the finalizer design (archival moved from the
bank-journal pipeline's load step to the terminal `qbo.journal.finalizer`).

## Commits

- `c8d3f06` feat(qbo_to_odoo): year-end closing entries pipeline
- `2ffa474` test(qbo_to_odoo): align deleted-journal archival test with the finalizer design

## Related

Consumed by the `verajet/odoo` MR enabling this for Vera Inkjet (task 4096).